### PR TITLE
[Feat] MapKit으로 주소 검색 기능으로 상세주소, 좌표, 건물명 불러오는 기능 구현

### DIFF
--- a/Carmunication.xcodeproj/project.pbxproj
+++ b/Carmunication.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		C93D2CD82AD28F7400CF4735 /* SelectBoardingCrewModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93D2CD72AD28F7400CF4735 /* SelectBoardingCrewModalView.swift */; };
 		C93D2CDA2AD28F8F00CF4735 /* SelectBoardingCrewModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93D2CD92AD28F8F00CF4735 /* SelectBoardingCrewModalViewController.swift */; };
 		C93D2CDC2AD298C400CF4735 /* GroupAddModalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93D2CDB2AD298C300CF4735 /* GroupAddModalCollectionViewCell.swift */; };
+		C954F6172AD9998500D528F5 /* SelectAddressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C954F6162AD9998500D528F5 /* SelectAddressModel.swift */; };
 		C96A74EC2ACE451900451C64 /* GroupDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96A74EB2ACE451900451C64 /* GroupDetailTableViewCell.swift */; };
 		C96A74EE2ACE4B5C00451C64 /* GradientLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96A74ED2ACE4B5C00451C64 /* GradientLineView.swift */; };
 		C9DC0CC82AD7D83700F06169 /* DefaultAddressTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC0CC72AD7D83700F06169 /* DefaultAddressTableViewCell.swift */; };
@@ -153,6 +154,7 @@
 		C93D2CD72AD28F7400CF4735 /* SelectBoardingCrewModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBoardingCrewModalView.swift; sourceTree = "<group>"; };
 		C93D2CD92AD28F8F00CF4735 /* SelectBoardingCrewModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBoardingCrewModalViewController.swift; sourceTree = "<group>"; };
 		C93D2CDB2AD298C300CF4735 /* GroupAddModalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupAddModalCollectionViewCell.swift; sourceTree = "<group>"; };
+		C954F6162AD9998500D528F5 /* SelectAddressModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAddressModel.swift; sourceTree = "<group>"; };
 		C96A74EB2ACE451900451C64 /* GroupDetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailTableViewCell.swift; sourceTree = "<group>"; };
 		C96A74ED2ACE4B5C00451C64 /* GradientLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientLineView.swift; sourceTree = "<group>"; };
 		C9DC0CC72AD7D83700F06169 /* DefaultAddressTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAddressTableViewCell.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 		16E42CDE2AC47E790031486E /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				C954F6152AD9996A00D528F5 /* GroupAdd */,
 				C92CFB3E2ACC24E80068273A /* DummyData */,
 				C92CFB372ACBC9090068273A /* Font */,
 				C92CFB362AC9B6CD0068273A /* Color */,
@@ -389,6 +392,14 @@
 			path = DummyData;
 			sourceTree = "<group>";
 		};
+		C954F6152AD9996A00D528F5 /* GroupAdd */ = {
+			isa = PBXGroup;
+			children = (
+				C954F6162AD9998500D528F5 /* SelectAddressModel.swift */,
+			);
+			path = GroupAdd;
+			sourceTree = "<group>";
+		};
 		C9DE7C312AC01B04005AFCC6 /* SessionList */ = {
 			isa = PBXGroup;
 			children = (
@@ -539,6 +550,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF9BCFF32ACE379C009DAECD /* SelectAddressView.swift in Sources */,
+				C954F6172AD9998500D528F5 /* SelectAddressModel.swift in Sources */,
 				BF29DF292ACFF9CD00430031 /* SessionListView.swift in Sources */,
 				B8DD15E42AD52D2F00685E48 /* FriendAddView.swift in Sources */,
 				C9DE7C352AC01C33005AFCC6 /* GroupAddViewController.swift in Sources */,

--- a/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
+++ b/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
@@ -20,6 +20,7 @@ import SnapKit
 final class SelectAddressViewController: UIViewController {
 
     private let selectAddressView = SelectAddressView()
+    private let selectAddressModel = SelectAddressModel()
     private var isKeyboardActive = false
     private var searchCompleter: MKLocalSearchCompleter?
     private var completerResults: [MKLocalSearchCompletion]?

--- a/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
+++ b/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
@@ -10,9 +10,33 @@ import UIKit
 
 import SnapKit
 
+/**
+ searchCompleter: MKLocalSearchCompleter // 검색을 도와주는 변수
+ searchRegion: MKCoordinateRegion // 검색 지역 범위를 결정하는 변수
+ completerResults: [MKLocalSearchCompletion] // 검색한 결과를 담는 변수
+ places: MKMapItem // tableView에서 선택한 Location의 정보를 담는 변수
+ localSearch: MKLocalSearch? // tableView에서 선택한 Location의 정보를 가져오는 변수
+ */
 final class SelectAddressViewController: UIViewController {
 
     private let selectAddressView = SelectAddressView()
+
+    private var searchCompleter: MKLocalSearchCompleter?
+    private var completerResults: [MKLocalSearchCompletion]?
+
+    private var places: MKMapItem? {
+        didSet {
+            selectAddressView.tableViewComponent.reloadData()
+        }
+    }
+
+    private var localSearch: MKLocalSearch? {
+        willSet {
+            // Clear the results and cancel the currently running local search before starting a new search.
+            places = nil
+            localSearch?.cancel()
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,12 +68,27 @@ final class SelectAddressViewController: UIViewController {
             for: .editingChanged
         )
 
+        let koreaCoordinate = CLLocationCoordinate2D(latitude: 36.34, longitude: 127.77)
+        let koreaBounds = MKCoordinateRegion(center: koreaCoordinate, latitudinalMeters: 200000, longitudinalMeters: 200000)
+
+        searchCompleter = MKLocalSearchCompleter()
+//        selectAddressView.searchBar.becomeFirstResponder()
+        searchCompleter?.delegate = self
+        searchCompleter?.resultTypes = .query
+        searchCompleter?.region = koreaBounds
+
+        selectAddressView.searchBar.delegate = self
         selectAddressView.friendSearchTextField.delegate = self
         selectAddressView.tableViewComponent.delegate = self
         selectAddressView.tableViewComponent.dataSource = self
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissTextField))
         view.addGestureRecognizer(tapGesture)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        searchCompleter = nil
     }
 }
 
@@ -62,9 +101,12 @@ extension SelectAddressViewController {
     }
 
     // [검색] 버튼을 눌렀을 때 동작
-    @objc private func performFriendSearch() {
+    @objc private func performFriendSearch(_ textField: UITextField) {
         // TODO: - 친구 검색 기능 구현 필요
         print("친구 검색")
+        if let searchText = textField.text {
+            performDetailedSearch(for: searchText)
+        }
     }
 
     // 텍스트필드 clear 버튼 눌렀을 때 동작
@@ -80,9 +122,73 @@ extension SelectAddressViewController {
         selectAddressView.friendSearchTextField.resignFirstResponder() // 최초 응답자 해제
     }
 
-    @objc private func textFieldDidChange() {
+    @objc private func textFieldDidChange(_ textField: UITextField) {
         // 텍스트 필드 내용이 변경될 때마다 호출되는 메서드
+        if let searchText = textField.text {
+            if searchText == "" {
+                completerResults?.removeAll()
+                selectAddressView.tableViewComponent.reloadData()
+            }
+            searchCompleter?.queryFragment = searchText
+            selectAddressView.tableViewComponent.reloadData()
+        }
+    }
+
+    func performDetailedSearch(for searchText: String) {
+        // searchText를 사용하여 원하는 검색 작업 수행
+        // 예를 들어, MKLocalSearch를 사용하여 위치 검색을 수행할 수 있습니다.
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = searchText
+
+        // 검색 요청 제출
+        let localSearch = MKLocalSearch(request: request)
+        localSearch.start { (response, error) in
+            if let error = error {
+                print("Error performing search: \(error.localizedDescription)")
+            } else if let response = response {
+                // 검색 결과를 response에서 처리
+                if let firstMapItem = response.mapItems.first {
+                    // 첫 번째 결과 항목을 사용하여 상세 정보 표시 또는 원하는 동작 수행
+                    print("검색 결과: \(firstMapItem.name ?? "알 수 없음")")
+                } else {
+                    print("검색 결과 없음")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - UISearchBarDelegate Method
+extension SelectAddressViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        if searchText == "" {
+            completerResults?.removeAll()
+            selectAddressView.tableViewComponent.reloadData()
+        }
+
+        searchCompleter?.queryFragment = searchText
         selectAddressView.tableViewComponent.reloadData()
+    }
+}
+
+// MARK: - MKLocalSearchCompleterDelegate Method
+extension SelectAddressViewController: MKLocalSearchCompleterDelegate {
+    // 자동완성 완료시 결과를 받는 method
+    func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+
+        completerResults = completer.results
+        selectAddressView.tableViewComponent.reloadData()
+    }
+
+    func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
+        if let error = error as NSError? {
+            print(
+"""
+MKLocalSearchCompleter encountered an error: \(error.localizedDescription).\n
+The query fragment is: \"\(completer.queryFragment)\"
+"""
+            )
+        }
     }
 }
 
@@ -91,6 +197,7 @@ extension SelectAddressViewController: UITextFieldDelegate {
 
     // 텍스트 필드의 편집이 시작될 때 호출되는 메서드
     func textFieldDidBeginEditing(_ textField: UITextField) {
+
         selectAddressView.friendSearchTextFieldView.backgroundColor = UIColor.semantic.backgroundSecond
         selectAddressView.friendSearchTextFieldView.layer.borderWidth = 0
         selectAddressView.tableViewComponent.reloadData()
@@ -120,27 +227,38 @@ extension SelectAddressViewController: UITableViewDelegate {
 extension SelectAddressViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return selectAddressView.friendSearchTextField.hasText ? 10 : 1
+//        if selectAddressView.friendSearchTextField.hasText {
+//            return completerResults?.count ?? 0
+//        } else {
+//            return 1
+//        }
+        return completerResults?.count ?? 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
-        if selectAddressView.friendSearchTextField.hasText {
-            if let cell = tableView.dequeueReusableCell(
-                withIdentifier: "selectAddressCell",
-                for: indexPath
-            ) as? SelectAddressTableViewCell {
-                return cell
+//        if selectAddressView.searchBar. {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: "selectAddressCell"
+            ) as? SelectAddressTableViewCell else {
+                return UITableViewCell()
             }
-        } else {
-            if let cell = tableView.dequeueReusableCell(
-                withIdentifier: "defaultAddressCell",
-                for: indexPath
-            ) as? DefaultAddressTableViewCell {
-                return cell
+
+            if let suggestion = completerResults?[indexPath.row] {
+                cell.buildingNameLabel.text = suggestion.title
+                cell.detailAddressLabel.text = suggestion.subtitle
             }
-        }
-        return UITableViewCell()
+            return cell
+
+//        } else {
+//            if let cell = tableView.dequeueReusableCell(
+//                withIdentifier: "defaultAddressCell",
+//                for: indexPath
+//            ) as? DefaultAddressTableViewCell {
+//                return cell
+//            }
+//        }
+//        return UITableViewCell()
     }
 }
 

--- a/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
+++ b/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
@@ -220,7 +220,6 @@ extension SelectAddressViewController {
     private func removeCountryAndPostalCode(from subtitle: String) -> String {
         var modifiedSubtitle = subtitle
 
-        // 대한민국을 제거
         modifiedSubtitle = modifiedSubtitle.replacingOccurrences(of: "대한민국", with: "")
 
         // ", #####" 패턴을 제거
@@ -228,12 +227,9 @@ extension SelectAddressViewController {
             modifiedSubtitle = modifiedSubtitle.replacingCharacters(in: range, with: "")
         }
 
-        // "#####" 패턴을 제거
         if let range = modifiedSubtitle.range(of: "\\d{5}", options: .regularExpression) {
             modifiedSubtitle = modifiedSubtitle.replacingCharacters(in: range, with: "")
         }
-
-
 
         return modifiedSubtitle.trimmingCharacters(in: .whitespaces)
     }

--- a/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
+++ b/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
@@ -216,6 +216,20 @@ extension SelectAddressViewController {
             }
         }
     }
+
+    private func removeCountryAndPostalCode(from subtitle: String) -> String {
+        // 정규 표현식을 사용하여 국가 또는 우편번호(5자리)를 찾습니다.
+        var modifiedSubtitle = subtitle
+        modifiedSubtitle = modifiedSubtitle.replacingOccurrences(of: "대한민국", with: "")
+        modifiedSubtitle = modifiedSubtitle.replacingOccurrences(of: ", ", with: "")
+        modifiedSubtitle = modifiedSubtitle.replacingOccurrences(
+            of: "\\b\\d{5}\\b",
+            with: "",
+            options: .regularExpression
+        )
+
+        return modifiedSubtitle.trimmingCharacters(in: .whitespaces)
+    }
 }
 
 // MARK: - MKLocalSearchCompleterDelegate Method
@@ -301,7 +315,7 @@ extension SelectAddressViewController: UITableViewDataSource {
 
             if let suggestion = completerResults?[indexPath.row] {
                 cell.buildingNameLabel.text = suggestion.title
-                cell.detailAddressLabel.text = suggestion.subtitle
+                cell.detailAddressLabel.text = removeCountryAndPostalCode(from: suggestion.subtitle)
             }
             return cell
         } else { // 검색 결과가 없는 경우

--- a/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
+++ b/Carmunication/Controllers/SessionList/SelectAddressViewController.swift
@@ -218,15 +218,22 @@ extension SelectAddressViewController {
     }
 
     private func removeCountryAndPostalCode(from subtitle: String) -> String {
-        // 정규 표현식을 사용하여 국가 또는 우편번호(5자리)를 찾습니다.
         var modifiedSubtitle = subtitle
+
+        // 대한민국을 제거
         modifiedSubtitle = modifiedSubtitle.replacingOccurrences(of: "대한민국", with: "")
-        modifiedSubtitle = modifiedSubtitle.replacingOccurrences(of: ", ", with: "")
-        modifiedSubtitle = modifiedSubtitle.replacingOccurrences(
-            of: "\\b\\d{5}\\b",
-            with: "",
-            options: .regularExpression
-        )
+
+        // ", #####" 패턴을 제거
+        if let range = modifiedSubtitle.range(of: ", \\d{5}", options: .regularExpression) {
+            modifiedSubtitle = modifiedSubtitle.replacingCharacters(in: range, with: "")
+        }
+
+        // "#####" 패턴을 제거
+        if let range = modifiedSubtitle.range(of: "\\d{5}", options: .regularExpression) {
+            modifiedSubtitle = modifiedSubtitle.replacingCharacters(in: range, with: "")
+        }
+
+
 
         return modifiedSubtitle.trimmingCharacters(in: .whitespaces)
     }

--- a/Carmunication/Models/GroupAdd/SelectAddressModel.swift
+++ b/Carmunication/Models/GroupAdd/SelectAddressModel.swift
@@ -1,0 +1,14 @@
+//
+//  SelectAddressModel.swift
+//  Carmunication
+//
+//  Created by 김동현 on 2023/10/14.
+//
+
+import Foundation
+
+struct SelectAddressModel {
+    var buildingName: String?
+    var detailAddress: String?
+    var coordinate: (Double, Double)?
+}

--- a/Carmunication/Views/SessionList/GroupAdd/DefaultAddressTableViewCell.swift
+++ b/Carmunication/Views/SessionList/GroupAdd/DefaultAddressTableViewCell.swift
@@ -45,7 +45,7 @@ class DefaultAddressTableViewCell: UITableViewCell {
         }
 
         cellTextLabel.snp.makeConstraints { make in
-            make.centerX.centerY.equalToSuperview()
+            make.centerX.centerY.equalTo(cellBackgroundImage)
         }
     }
 

--- a/Carmunication/Views/SessionList/GroupAdd/DefaultAddressTableViewCell.swift
+++ b/Carmunication/Views/SessionList/GroupAdd/DefaultAddressTableViewCell.swift
@@ -45,7 +45,7 @@ class DefaultAddressTableViewCell: UITableViewCell {
         }
 
         cellTextLabel.snp.makeConstraints { make in
-            make.centerX.centerY.equalTo(cellBackgroundImage)
+            make.center.equalTo(cellBackgroundImage)
         }
     }
 

--- a/Carmunication/Views/SessionList/GroupAdd/SelectAddressView.swift
+++ b/Carmunication/Views/SessionList/GroupAdd/SelectAddressView.swift
@@ -71,6 +71,15 @@ final class SelectAddressView: UIView {
         return friendSearchTextField
     }()
 
+    lazy var searchBar: UISearchBar = {
+        let searchBar = UISearchBar()
+        searchBar.placeholder = "주소지를 검색하세요"
+        searchBar.searchTextField.textColor = UIColor.semantic.textPrimary
+        searchBar.searchTextField.autocapitalizationType = .none
+
+        return searchBar
+    }()
+
     // MARK: - 텍스트 필드 우측 스택
     private lazy var textFieldUtilityStackView: UIStackView = {
         let textFieldUtilityStackView = UIStackView()
@@ -126,6 +135,7 @@ final class SelectAddressView: UIView {
     private func setupUI() {
         addSubview(headerBar)
         addSubview(friendSearchTextFieldView)
+//        addSubview(searchBar)  // UITextField 대신 UISearchBar를 추가합니다.
         headerBar.addSubview(headerTitleLabel)
         headerBar.addSubview(closeButton)
         friendSearchTextFieldView.addSubview(friendSearchTextField)
@@ -166,6 +176,11 @@ final class SelectAddressView: UIView {
             make.top.bottom.equalToSuperview().inset(8)
         }
 
+//        searchBar.snp.makeConstraints { make in
+//            make.leading.trailing.equalToSuperview().inset(20)
+//            make.top.bottom.equalToSuperview().inset(8)
+//        }
+
         clearButton.snp.makeConstraints { make in
             make.trailing.equalTo(friendSearchButton.snp.leading).offset(-10)
         }
@@ -175,5 +190,10 @@ final class SelectAddressView: UIView {
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(safeAreaLayoutGuide).inset(20)
         }
+//        tableViewComponent.snp.makeConstraints { make in
+//            make.top.equalTo(searchBar.snp.bottom).offset(8)
+//            make.leading.trailing.equalToSuperview().inset(20)
+//            make.bottom.equalTo(safeAreaLayoutGuide).inset(20)
+//        }
     }
 }

--- a/Carmunication/Views/SessionList/GroupAdd/SelectAddressView.swift
+++ b/Carmunication/Views/SessionList/GroupAdd/SelectAddressView.swift
@@ -71,15 +71,6 @@ final class SelectAddressView: UIView {
         return friendSearchTextField
     }()
 
-    lazy var searchBar: UISearchBar = {
-        let searchBar = UISearchBar()
-        searchBar.placeholder = "주소지를 검색하세요"
-        searchBar.searchTextField.textColor = UIColor.semantic.textPrimary
-        searchBar.searchTextField.autocapitalizationType = .none
-
-        return searchBar
-    }()
-
     // MARK: - 텍스트 필드 우측 스택
     private lazy var textFieldUtilityStackView: UIStackView = {
         let textFieldUtilityStackView = UIStackView()
@@ -135,7 +126,6 @@ final class SelectAddressView: UIView {
     private func setupUI() {
         addSubview(headerBar)
         addSubview(friendSearchTextFieldView)
-//        addSubview(searchBar)  // UITextField 대신 UISearchBar를 추가합니다.
         headerBar.addSubview(headerTitleLabel)
         headerBar.addSubview(closeButton)
         friendSearchTextFieldView.addSubview(friendSearchTextField)
@@ -176,11 +166,6 @@ final class SelectAddressView: UIView {
             make.top.bottom.equalToSuperview().inset(8)
         }
 
-//        searchBar.snp.makeConstraints { make in
-//            make.leading.trailing.equalToSuperview().inset(20)
-//            make.top.bottom.equalToSuperview().inset(8)
-//        }
-
         clearButton.snp.makeConstraints { make in
             make.trailing.equalTo(friendSearchButton.snp.leading).offset(-10)
         }
@@ -190,10 +175,5 @@ final class SelectAddressView: UIView {
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(safeAreaLayoutGuide).inset(20)
         }
-//        tableViewComponent.snp.makeConstraints { make in
-//            make.top.equalTo(searchBar.snp.bottom).offset(8)
-//            make.leading.trailing.equalToSuperview().inset(20)
-//            make.bottom.equalTo(safeAreaLayoutGuide).inset(20)
-//        }
     }
 }


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Feat: 새로운 기능을 추가

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

주소 검색에 대한 로직을 뷰에 입혔습니다.
MapKit을 활용해 자동 완성 기능을 구현할 수 있었습니다만, 받아오는 데이터 자체가 광범위하고 지역설정이 거의 불가능하여 전 세계적으로 검색이 가능할 수 밖에 없었습니다. 이를 해결해보기 위해 좌표 값을 포인트별로 변환하여, 특정 좌표 내부에 있는지를 확인하고 그것들만 필터링해서 보여주는 방식으로 구현하려고 했으나, 프레임워크 자체에서 geocode를 1분에 50번의 리퀘스트만 허용하는 바람에, 필터링은 거의 불가능하게 되었습니다.

다만, 정확도 자체는 있고, 자동 완성에서 나오지 않아도, 상세주소를 입력하고 검색을 누르면 위도와 경도는 정확히 받아집니다.

현재 미구현된 사항은, 주소를 찾을 수 없을 때, 테이블뷰 셀의 텍스트를 "주소를 찾을 수 없습니다"로 바꿔놓고 싶은데, 뷰 컨트롤러가 너무 커지는 상황이라 더 구현하면 어지러울 것 같아 잘라서 PR을 올리기로 하였습니다.

맵뷰를 구현하고 나서 전체적으로 손보도록 하겠습니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #55 

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #61 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/592b98e2-7ec5-4828-9ef1-31e0f38ee405


<img width="300" alt="" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/568563db-32ce-4a5e-b852-2dd60149c728">


![스크린샷 2023-10-14 오전 1 25 39](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/e5399715-04b4-46b6-9bbe-beaa383ba598)
