### PR TITLE
[Feat] 맵뷰 하단에 상세 뷰 그리기

### DIFF
--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		B8EECEA22ACD6598004D310C /* KeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EECEA12ACD6598004D310C /* KeychainItem.swift */; };
 		BF0AEF9C2ACD7F7600FBB7B8 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = BF0AEF9B2ACD7F7600FBB7B8 /* .swiftlint.yml */; };
 		BF0C33022AE50AFB00A6D8FE /* SessionMapDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */; };
+		BF0C33042AE51E7C00A6D8FE /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C33032AE51E7C00A6D8FE /* PaddingLabel.swift */; };
 		BF24481D2AD6D66200F4089A /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = BF24481C2AD6D66200F4089A /* FirebaseDatabase */; };
 		BF29DF292ACFF9CD00430031 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF29DF282ACFF9CD00430031 /* SessionListView.swift */; };
 		BF29DF2B2ACFFDBC00430031 /* GroupDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF29DF2A2ACFFDBC00430031 /* GroupDetailView.swift */; };
@@ -128,6 +129,7 @@
 		B8EECEA12ACD6598004D310C /* KeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItem.swift; sourceTree = "<group>"; };
 		BF0AEF9B2ACD7F7600FBB7B8 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMapDetailView.swift; sourceTree = "<group>"; };
+		BF0C33032AE51E7C00A6D8FE /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		BF29DF282ACFF9CD00430031 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		BF29DF2A2ACFFDBC00430031 /* GroupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailView.swift; sourceTree = "<group>"; };
 		BF37D9C92AB939A3005331AD /* Carmu.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Carmu.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -491,6 +493,7 @@
 			isa = PBXGroup;
 			children = (
 				C95C07AD2AE0BB5A007E7589 /* FirebaseManager.swift */,
+				BF0C33032AE51E7C00A6D8FE /* PaddingLabel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				B8D507342ADDA3EE00404E7C /* NoSearchedResultTableViewCell.swift in Sources */,
 				BF9BCFF32ACE379C009DAECD /* SelectAddressView.swift in Sources */,
 				C954F6172AD9998500D528F5 /* SelectAddressModel.swift in Sources */,
+				BF0C33042AE51E7C00A6D8FE /* PaddingLabel.swift in Sources */,
 				BF29DF292ACFF9CD00430031 /* SessionListView.swift in Sources */,
 				B8DD15E42AD52D2F00685E48 /* FriendAddView.swift in Sources */,
 				C9DE7C352AC01C33005AFCC6 /* GroupAddViewController.swift in Sources */,

--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		B8EECE9C2AC96BE5004D310C /* PrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EECE9B2AC96BE5004D310C /* PrivacyViewController.swift */; };
 		B8EECEA22ACD6598004D310C /* KeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EECEA12ACD6598004D310C /* KeychainItem.swift */; };
 		BF0AEF9C2ACD7F7600FBB7B8 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = BF0AEF9B2ACD7F7600FBB7B8 /* .swiftlint.yml */; };
+		BF0C33022AE50AFB00A6D8FE /* SessionMapDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */; };
 		BF24481D2AD6D66200F4089A /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = BF24481C2AD6D66200F4089A /* FirebaseDatabase */; };
 		BF29DF292ACFF9CD00430031 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF29DF282ACFF9CD00430031 /* SessionListView.swift */; };
 		BF29DF2B2ACFFDBC00430031 /* GroupDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF29DF2A2ACFFDBC00430031 /* GroupDetailView.swift */; };
@@ -126,6 +127,7 @@
 		B8EECE9B2AC96BE5004D310C /* PrivacyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewController.swift; sourceTree = "<group>"; };
 		B8EECEA12ACD6598004D310C /* KeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItem.swift; sourceTree = "<group>"; };
 		BF0AEF9B2ACD7F7600FBB7B8 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMapDetailView.swift; sourceTree = "<group>"; };
 		BF29DF282ACFF9CD00430031 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		BF29DF2A2ACFFDBC00430031 /* GroupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailView.swift; sourceTree = "<group>"; };
 		BF37D9C92AB939A3005331AD /* Carmu.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Carmu.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -375,6 +377,7 @@
 				16DBA63E2AC1D5B900315ED7 /* GroupCollectionViewCell.swift */,
 				16A84F772AD7E0F600C28F5F /* SessionStartMidView.swift */,
 				161854AC2AE005F200961D2D /* SessionStartMidNoGroupView.swift */,
+				BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */,
 			);
 			path = SessionStart;
 			sourceTree = "<group>";
@@ -663,6 +666,7 @@
 				C9DC0CCA2AD7D85400F06169 /* SelectAddressTableViewCell.swift in Sources */,
 				C904D1632AD57B21008BF5CE /* Session.swift in Sources */,
 				BF5F3C4D2ABD778B004AFC73 /* MainTabBarViewController.swift in Sources */,
+				BF0C33022AE50AFB00A6D8FE /* SessionMapDetailView.swift in Sources */,
 				C92CFB3B2ACBF6C40068273A /* UIImage+Extension.swift in Sources */,
 				B8DD15EE2AD6EE9400685E48 /* CustomIntensityVisualEffectView.swift in Sources */,
 				B8DD15E02AD4677800685E48 /* FriendListTableViewCell.swift in Sources */,

--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		BF0AEF9C2ACD7F7600FBB7B8 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = BF0AEF9B2ACD7F7600FBB7B8 /* .swiftlint.yml */; };
 		BF0C33022AE50AFB00A6D8FE /* SessionMapDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */; };
 		BF0C33042AE51E7C00A6D8FE /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C33032AE51E7C00A6D8FE /* PaddingLabel.swift */; };
+		BF0C33092AE5239700A6D8FE /* TimeDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C33082AE5239700A6D8FE /* TimeDataView.swift */; };
 		BF24481D2AD6D66200F4089A /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = BF24481C2AD6D66200F4089A /* FirebaseDatabase */; };
 		BF29DF292ACFF9CD00430031 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF29DF282ACFF9CD00430031 /* SessionListView.swift */; };
 		BF29DF2B2ACFFDBC00430031 /* GroupDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF29DF2A2ACFFDBC00430031 /* GroupDetailView.swift */; };
@@ -130,6 +131,7 @@
 		BF0AEF9B2ACD7F7600FBB7B8 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMapDetailView.swift; sourceTree = "<group>"; };
 		BF0C33032AE51E7C00A6D8FE /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
+		BF0C33082AE5239700A6D8FE /* TimeDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeDataView.swift; sourceTree = "<group>"; };
 		BF29DF282ACFF9CD00430031 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		BF29DF2A2ACFFDBC00430031 /* GroupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailView.swift; sourceTree = "<group>"; };
 		BF37D9C92AB939A3005331AD /* Carmu.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Carmu.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -257,6 +259,15 @@
 			path = MyPage;
 			sourceTree = "<group>";
 		};
+		BF0C33052AE5217100A6D8FE /* SessionMapView */ = {
+			isa = PBXGroup;
+			children = (
+				BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */,
+				BF0C33082AE5239700A6D8FE /* TimeDataView.swift */,
+			);
+			path = SessionMapView;
+			sourceTree = "<group>";
+		};
 		BF24481B2AD6D66200F4089A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -379,7 +390,7 @@
 				16DBA63E2AC1D5B900315ED7 /* GroupCollectionViewCell.swift */,
 				16A84F772AD7E0F600C28F5F /* SessionStartMidView.swift */,
 				161854AC2AE005F200961D2D /* SessionStartMidNoGroupView.swift */,
-				BF0C33012AE50AFB00A6D8FE /* SessionMapDetailView.swift */,
+				BF0C33052AE5217100A6D8FE /* SessionMapView */,
 			);
 			path = SessionStart;
 			sourceTree = "<group>";
@@ -671,6 +682,7 @@
 				C904D1632AD57B21008BF5CE /* Session.swift in Sources */,
 				BF5F3C4D2ABD778B004AFC73 /* MainTabBarViewController.swift in Sources */,
 				BF0C33022AE50AFB00A6D8FE /* SessionMapDetailView.swift in Sources */,
+				BF0C33092AE5239700A6D8FE /* TimeDataView.swift in Sources */,
 				C92CFB3B2ACBF6C40068273A /* UIImage+Extension.swift in Sources */,
 				B8DD15EE2AD6EE9400685E48 /* CustomIntensityVisualEffectView.swift in Sources */,
 				B8DD15E02AD4677800685E48 /* FriendListTableViewCell.swift in Sources */,

--- a/Carmu/Sources/Controllers/SessionStart/SessionMapViewController.swift
+++ b/Carmu/Sources/Controllers/SessionStart/SessionMapViewController.swift
@@ -29,6 +29,7 @@ struct Points {
 final class SessionMapViewController: UIViewController {
 
     private let mapView = NMFMapView()
+    private let sessionMapDetailView = SessionMapDetailView()
     // 자동차 위치를 표시하기 위한 마커
     private let carMarker = NMFMarker()
     private let locationManager = CLLocationManager()
@@ -77,9 +78,16 @@ final class SessionMapViewController: UIViewController {
     }
 
     private func showNaverMap() {
+        view.addSubview(sessionMapDetailView)
+        sessionMapDetailView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.height.equalTo(234)
+        }
+
         view.addSubview(mapView)
         mapView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.leading.top.trailing.equalToSuperview()
+            make.bottom.equalTo(sessionMapDetailView.snp.top)
         }
     }
 

--- a/Carmu/Sources/Models/Color/SemanticColor.swift
+++ b/Carmu/Sources/Models/Color/SemanticColor.swift
@@ -17,6 +17,7 @@ struct SemanticColor {
     let backgroundAddress = UIColor.theme.gray1
     let backgroundTouchable = UIColor.theme.blue2
     let backgroundDisableBT = UIColor.theme.blue1
+    let backgroundList = UIColor.theme.gray1
 
     let textPrimary = UIColor.theme.darkblue8
     let textSecondary = UIColor.theme.white

--- a/Carmu/Sources/Utils/PaddingLabel.swift
+++ b/Carmu/Sources/Utils/PaddingLabel.swift
@@ -1,0 +1,28 @@
+//
+//  PaddingLabel.swift
+//  Carmu
+//
+//  Created by 허준혁 on 10/22/23.
+//
+
+import UIKit
+
+final class PaddingLabel: UILabel {
+    private var padding = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
+
+    convenience init(padding: UIEdgeInsets) {
+        self.init()
+        self.padding = padding
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: padding))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+        return contentSize
+    }
+}

--- a/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
@@ -27,12 +27,21 @@ final class SessionMapDetailView: UIView {
         return button
     }()
 
+    private let addressLabel: UILabel = {
+        let label = UILabel()
+        label.text = "양덕 농협지점"
+        label.font = UIFont.carmuFont.headline1
+        label.textColor = UIColor.semantic.textPrimary
+        return label
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         backgroundColor = UIColor.semantic.backgroundDefault
 
         showNoticeLateButton()
+        showAddressLabel()
     }
 
     required init?(coder: NSCoder) {
@@ -44,6 +53,14 @@ final class SessionMapDetailView: UIView {
         noticeLateButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(48)
+        }
+    }
+
+    private func showAddressLabel() {
+        addSubview(addressLabel)
+        addressLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(20)
+            make.bottom.equalTo(noticeLateButton.snp.top).offset(-20)
         }
     }
 }

--- a/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
@@ -11,6 +11,16 @@ import SnapKit
 
 final class SessionMapDetailView: UIView {
 
+    private let titleLabel: UILabel = {
+        let label = PaddingLabel(padding: UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20))
+        label.backgroundColor = UIColor.semantic.backgroundSecond
+        label.text = "🍎 C5 출근팟 늦으면 죽음 뿐 🍎"
+        label.textColor = UIColor.semantic.textPrimary
+        label.font = UIFont.carmuFont.subhead3
+        label.textAlignment = .center
+        return label
+    }()
+
     let noticeLateButton: UIButton = {
         var config = UIButton.Configuration.filled()
 
@@ -48,6 +58,7 @@ final class SessionMapDetailView: UIView {
 
         backgroundColor = UIColor.semantic.backgroundDefault
 
+        showTitleLabel()
         showNoticeLateButton()
         showAddressLabel()
         showPointLabel()
@@ -55,6 +66,13 @@ final class SessionMapDetailView: UIView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    private func showTitleLabel() {
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+        }
     }
 
     private func showNoticeLateButton() {

--- a/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
@@ -1,0 +1,49 @@
+//
+//  SessionMapDetailView.swift
+//  Carmu
+//
+//  Created by 허준혁 on 10/22/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SessionMapDetailView: UIView {
+
+    let noticeLateButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+
+        var titleContainer = AttributeContainer()
+        titleContainer.font = UIFont.carmuFont.headline2
+        titleContainer.foregroundColor = UIColor.semantic.textSecondary
+
+        config.attributedTitle = AttributedString("지각 알리기", attributes: titleContainer)
+        config.contentInsets = NSDirectionalEdgeInsets(top: 13, leading: 20, bottom: 13, trailing: 20)
+        config.cornerStyle = .capsule
+        config.baseBackgroundColor = UIColor.semantic.accPrimary
+
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = UIColor.semantic.backgroundDefault
+
+        showNoticeLateButton()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    private func showNoticeLateButton() {
+        addSubview(noticeLateButton)
+        noticeLateButton.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(48)
+        }
+    }
+}

--- a/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionMapDetailView.swift
@@ -35,6 +35,14 @@ final class SessionMapDetailView: UIView {
         return label
     }()
 
+    private let pointLabel: UILabel = {
+        let label = UILabel()
+        label.text = "출발지"
+        label.font = UIFont.carmuFont.subhead1
+        label.textColor = UIColor.semantic.textBody
+        return label
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -42,6 +50,7 @@ final class SessionMapDetailView: UIView {
 
         showNoticeLateButton()
         showAddressLabel()
+        showPointLabel()
     }
 
     required init?(coder: NSCoder) {
@@ -61,6 +70,14 @@ final class SessionMapDetailView: UIView {
         addressLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(20)
             make.bottom.equalTo(noticeLateButton.snp.top).offset(-20)
+        }
+    }
+
+    private func showPointLabel() {
+        addSubview(pointLabel)
+        pointLabel.snp.makeConstraints { make in
+            make.leading.equalTo(addressLabel)
+            make.bottom.equalTo(addressLabel.snp.top).offset(-4)
         }
     }
 }

--- a/Carmu/Sources/Views/SessionStart/SessionMapView/SessionMapDetailView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionMapView/SessionMapDetailView.swift
@@ -53,6 +53,9 @@ final class SessionMapDetailView: UIView {
         return label
     }()
 
+    private let actualTime = TimeDataView()
+    private let plannedTime = TimeDataView()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -62,6 +65,7 @@ final class SessionMapDetailView: UIView {
         showNoticeLateButton()
         showAddressLabel()
         showPointLabel()
+        showTimeInfo()
     }
 
     required init?(coder: NSCoder) {
@@ -97,5 +101,31 @@ final class SessionMapDetailView: UIView {
             make.leading.equalTo(addressLabel)
             make.bottom.equalTo(addressLabel.snp.top).offset(-4)
         }
+    }
+
+    private func showTimeInfo() {
+        // 실제 시간
+        addSubview(actualTime)
+        actualTime.snp.makeConstraints { make in
+            make.trailing.equalTo(noticeLateButton)
+            make.bottom.equalTo(addressLabel)
+        }
+        actualTime.titleLabel.text = "예정"
+        actualTime.titleLabel.textColor = UIColor.semantic.accPrimary
+        actualTime.titleLabel.backgroundColor = UIColor.semantic.backgroundSecond
+        actualTime.timeLabel.text = "00:00"
+        actualTime.timeLabel.textColor = UIColor.semantic.accPrimary
+
+        // 계획 시간
+        addSubview(plannedTime)
+        plannedTime.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-103)
+            make.bottom.equalTo(actualTime)
+        }
+        plannedTime.titleLabel.text = "계획"
+        plannedTime.titleLabel.textColor = UIColor.semantic.textBody
+        plannedTime.titleLabel.backgroundColor = UIColor.semantic.backgroundList
+        plannedTime.timeLabel.text = "00:00"
+        plannedTime.timeLabel.textColor = UIColor.semantic.textBody
     }
 }

--- a/Carmu/Sources/Views/SessionStart/SessionMapView/TimeDataView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionMapView/TimeDataView.swift
@@ -1,0 +1,48 @@
+//
+//  TimeDataView.swift
+//  Carmu
+//
+//  Created by 허준혁 on 10/22/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class TimeDataView: UIView {
+
+    let titleLabel: UILabel = {
+        let label = PaddingLabel(padding: UIEdgeInsets(top: 2, left: 4, bottom: 2, right: 4))
+        label.font = UIFont.carmuFont.body1
+        label.layer.masksToBounds = true
+        label.layer.cornerRadius = 10.0
+        label.backgroundColor = UIColor.semantic.backgroundList // 임시로 넣음
+        return label
+    }()
+
+    let timeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.carmuFont.body3
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        addSubview(timeLabel)
+        timeLabel.snp.makeConstraints { make in
+            make.trailing.equalToSuperview()
+            make.top.bottom.equalToSuperview().inset(3)
+        }
+
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.trailing.equalTo(timeLabel.snp.leading).offset(-2)
+            make.top.bottom.equalTo(timeLabel)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Design: CSS 등 사용자 UI 디자인 변경

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

SessionMapView 하단에 출발지, 경유지, 도착지의 상세정보를 표시할 레이아웃을 작성했습니다.
각 경유지 선택시 상세정보가 바뀌도록 구현할 예정이었으나 소스코드가 길어지는 관계로 다음 이슈에서 작업하겠습니다

- [x] 상세뷰 그리기
- [ ] 출발지, 경유지, 도착지 버튼 선택시 정보 변경

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #102 

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #102

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

<img width="300" alt="" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/22979718/bd1efc67-aa7e-4499-aaa4-14b3cda29a00">

