### PR TITLE
[Feat] 크루 생성 - 탑승지 설정 화면 구현(동승자)

### DIFF
--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		C9F43BDB2AF2700400BAA0E3 /* InviteCodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BDA2AF2700400BAA0E3 /* InviteCodeInputView.swift */; };
 		C9F43BDD2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BDC2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift */; };
 		C9F43BDF2AF2C09500BAA0E3 /* BoardingPointSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BDE2AF2C09500BAA0E3 /* BoardingPointSelectView.swift */; };
+		C9F43BE12AF3430C00BAA0E3 /* StopoverSelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BE02AF3430C00BAA0E3 /* StopoverSelectButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -157,6 +158,7 @@
 		C9F43BDA2AF2700400BAA0E3 /* InviteCodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeInputView.swift; sourceTree = "<group>"; };
 		C9F43BDC2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardingPointSelectViewController.swift; sourceTree = "<group>"; };
 		C9F43BDE2AF2C09500BAA0E3 /* BoardingPointSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardingPointSelectView.swift; sourceTree = "<group>"; };
+		C9F43BE02AF3430C00BAA0E3 /* StopoverSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverSelectButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -407,6 +409,7 @@
 				BF0C33032AE51E7C00A6D8FE /* PaddingLabel.swift */,
 				C9F43BCF2AF2186A00BAA0E3 /* CrewMakeUtil.swift */,
 				C9F43BD12AF227B100BAA0E3 /* LargeSelectButton.swift */,
+				C9F43BE02AF3430C00BAA0E3 /* StopoverSelectButton.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -581,6 +584,7 @@
 				B8DD15E22AD52CC300685E48 /* FriendAddViewController.swift in Sources */,
 				BF37D9CD2AB939A3005331AD /* AppDelegate.swift in Sources */,
 				C92CFB332AC9B6760068273A /* ColorTheme.swift in Sources */,
+				C9F43BE12AF3430C00BAA0E3 /* StopoverSelectButton.swift in Sources */,
 				C9C7C1212ADE25590016DE13 /* String+Extension.swift in Sources */,
 				C95C07AE2AE0BB5A007E7589 /* FirebaseManager.swift in Sources */,
 				B8A20E422AC0BC8900F0CE91 /* LoginViewController.swift in Sources */,

--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		C9F43BD22AF227B100BAA0E3 /* LargeSelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BD12AF227B100BAA0E3 /* LargeSelectButton.swift */; };
 		C9F43BD92AF26FEE00BAA0E3 /* InviteCodeInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BD82AF26FEE00BAA0E3 /* InviteCodeInputViewController.swift */; };
 		C9F43BDB2AF2700400BAA0E3 /* InviteCodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BDA2AF2700400BAA0E3 /* InviteCodeInputView.swift */; };
+		C9F43BDD2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BDC2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift */; };
+		C9F43BDF2AF2C09500BAA0E3 /* BoardingPointSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F43BDE2AF2C09500BAA0E3 /* BoardingPointSelectView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -153,6 +155,8 @@
 		C9F43BD12AF227B100BAA0E3 /* LargeSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeSelectButton.swift; sourceTree = "<group>"; };
 		C9F43BD82AF26FEE00BAA0E3 /* InviteCodeInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeInputViewController.swift; sourceTree = "<group>"; };
 		C9F43BDA2AF2700400BAA0E3 /* InviteCodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeInputView.swift; sourceTree = "<group>"; };
+		C9F43BDC2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardingPointSelectViewController.swift; sourceTree = "<group>"; };
+		C9F43BDE2AF2C09500BAA0E3 /* BoardingPointSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardingPointSelectView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -412,6 +416,7 @@
 			children = (
 				C9F43BCA2AF2151500BAA0E3 /* PositionSelectViewController.swift */,
 				C9F43BD82AF26FEE00BAA0E3 /* InviteCodeInputViewController.swift */,
+				C9F43BDC2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift */,
 			);
 			path = CrewMake;
 			sourceTree = "<group>";
@@ -421,6 +426,7 @@
 			children = (
 				C9F43BCD2AF2155400BAA0E3 /* PositionSelectView.swift */,
 				C9F43BDA2AF2700400BAA0E3 /* InviteCodeInputView.swift */,
+				C9F43BDE2AF2C09500BAA0E3 /* BoardingPointSelectView.swift */,
 			);
 			path = CrewMake;
 			sourceTree = "<group>";
@@ -555,6 +561,7 @@
 				B8D73AC32AD2FBE600D211DE /* InquiryView.swift in Sources */,
 				B8EECE9A2AC96B5F004D310C /* InquiryViewController.swift in Sources */,
 				C9F43BDB2AF2700400BAA0E3 /* InviteCodeInputView.swift in Sources */,
+				C9F43BDD2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift in Sources */,
 				B8DD15EC2AD6CFBF00685E48 /* GiftCardCollectionViewCell.swift in Sources */,
 				C904D1652AD597C8008BF5CE /* DummyData.swift in Sources */,
 				BF9BCFFD2ACE458D009DAECD /* MyPageView.swift in Sources */,
@@ -570,6 +577,7 @@
 				BF4A12422ABED78400EC1B6D /* SessionStartViewController.swift in Sources */,
 				C9F43BD92AF26FEE00BAA0E3 /* InviteCodeInputViewController.swift in Sources */,
 				B8A3EFDD2AC5F5C600433F5C /* FriendListViewController.swift in Sources */,
+				C9F43BDF2AF2C09500BAA0E3 /* BoardingPointSelectView.swift in Sources */,
 				B8DD15E22AD52CC300685E48 /* FriendAddViewController.swift in Sources */,
 				BF37D9CD2AB939A3005331AD /* AppDelegate.swift in Sources */,
 				C92CFB332AC9B6760068273A /* ColorTheme.swift in Sources */,

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -29,8 +29,7 @@ final class BoardingPointSelectViewController: UIViewController {
 // MARK: - @objc Method
 extension BoardingPointSelectViewController {
     @objc private func stopoverPointTapped(_ sender: UIButton) {
-        sender.
-
+        
     }
 }
 

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -49,7 +49,7 @@ extension BoardingPointSelectViewController {
 
         // 선택한 버튼의 색상 변경
         sender.setSelectedButtonAppearance()
-        
+
         boardingPointSelectView.nextButton.backgroundColor = UIColor.semantic.accPrimary
         boardingPointSelectView.nextButton.isEnabled = true
         selectedPoint = sender.tag

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 final class BoardingPointSelectViewController: UIViewController {
 
     private let boardingPointSelectView = BoardingPointSelectView()
+    private var selectedButton: StopoverSelectButton?
+    private var selectedPoint: Int?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,8 +30,23 @@ final class BoardingPointSelectViewController: UIViewController {
 
 // MARK: - @objc Method
 extension BoardingPointSelectViewController {
-    @objc private func stopoverPointTapped(_ sender: UIButton) {
-        
+    @objc private func stopoverPointTapped(_ sender: StopoverSelectButton) {
+        if selectedButton == sender {
+            selectedButton?.resetButtonAppearance()
+            selectedPoint = nil
+            selectedButton = nil
+            return
+        }
+        // 이전에 선택한 버튼을 원래 상태로 복구
+        selectedButton?.resetButtonAppearance()
+
+        // 선택한 버튼 업데이트
+        selectedButton = sender
+
+        // 선택한 버튼의 색상 변경
+        sender.setSelectedButtonAppearance()
+        selectedPoint = sender.tag
+        print("버튼 태그: ", selectedPoint)
     }
 }
 

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -1,0 +1,34 @@
+//
+//  BoardingPointSelectViewController.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/2/23.
+//
+
+import UIKit
+
+class BoardingPointSelectViewController: UIViewController {
+
+    private let boardingPointSelectView = BoardingPointSelectView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.semantic.backgroundDefault
+
+        view.addSubview(boardingPointSelectView)
+        boardingPointSelectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - 프리뷰 canvas 세팅
+import SwiftUI
+
+struct BPSViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = BoardingPointSelectViewController
+    func makeUIViewController(context: Context) -> BoardingPointSelectViewController {
+        return BoardingPointSelectViewController()
+    }
+    func updateUIViewController(_ uiViewController: BoardingPointSelectViewController, context: Context) {}
+}

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BoardingPointSelectViewController: UIViewController {
+final class BoardingPointSelectViewController: UIViewController {
 
     private let boardingPointSelectView = BoardingPointSelectView()
 

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -17,14 +17,16 @@ final class BoardingPointSelectViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = UIColor.semantic.backgroundDefault
 
+        for element in boardingPointSelectView.customTableVieWCell {
+            element.addTarget(self, action: #selector(stopoverPointTapped), for: .touchUpInside)
+        }
+        boardingPointSelectView.nextButton.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
+
         view.addSubview(boardingPointSelectView)
         boardingPointSelectView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
 
-        for element in boardingPointSelectView.customTableVieWCell {
-            element.addTarget(self, action: #selector(stopoverPointTapped), for: .touchUpInside)
-        }
     }
 }
 
@@ -35,6 +37,8 @@ extension BoardingPointSelectViewController {
             selectedButton?.resetButtonAppearance()
             selectedPoint = nil
             selectedButton = nil
+            boardingPointSelectView.nextButton.backgroundColor = UIColor.semantic.backgroundThird
+            boardingPointSelectView.nextButton.isEnabled = false
             return
         }
         // 이전에 선택한 버튼을 원래 상태로 복구
@@ -45,8 +49,14 @@ extension BoardingPointSelectViewController {
 
         // 선택한 버튼의 색상 변경
         sender.setSelectedButtonAppearance()
+        
+        boardingPointSelectView.nextButton.backgroundColor = UIColor.semantic.accPrimary
+        boardingPointSelectView.nextButton.isEnabled = true
         selectedPoint = sender.tag
-        print("버튼 태그: ", selectedPoint)
+    }
+
+    @objc private func nextButtonTapped() {
+        // TODO: 다음화면 이동 구현 필요
     }
 }
 

--- a/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/BoardingPointSelectViewController.swift
@@ -19,6 +19,18 @@ final class BoardingPointSelectViewController: UIViewController {
         boardingPointSelectView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+
+        for element in boardingPointSelectView.customTableVieWCell {
+            element.addTarget(self, action: #selector(stopoverPointTapped), for: .touchUpInside)
+        }
+    }
+}
+
+// MARK: - @objc Method
+extension BoardingPointSelectViewController {
+    @objc private func stopoverPointTapped(_ sender: UIButton) {
+        sender.
+
     }
 }
 

--- a/Carmu/Sources/Models/Color/SemanticColor.swift
+++ b/Carmu/Sources/Models/Color/SemanticColor.swift
@@ -14,6 +14,7 @@ struct SemanticColor {
 
     let backgroundDefault = UIColor.theme.white
     let backgroundSecond = UIColor.theme.blue1
+    let backgroundThird = UIColor.theme.blue2
     let backgroundAddress = UIColor.theme.gray1
     let backgroundTouchable = UIColor.theme.blue2
     let backgroundDisableBT = UIColor.theme.blue1
@@ -31,5 +32,5 @@ struct SemanticColor {
     let error = UIColor.theme.red7
 
     let accPrimary = UIColor.theme.blue6
-    let accSecondary = UIColor.theme.acua6
+    let accSecondary = UIColor.theme.acua5
 }

--- a/Carmu/Sources/SceneDelegate.swift
+++ b/Carmu/Sources/SceneDelegate.swift
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // 로그인한 사용자가 있는지 체크
         if Auth.auth().currentUser != nil {
-            window.rootViewController = SessionStartViewController()
+            window.rootViewController = BoardingPointSelectViewController()
         } else {
             window.rootViewController = LoginViewController()
         }

--- a/Carmu/Sources/SceneDelegate.swift
+++ b/Carmu/Sources/SceneDelegate.swift
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // 로그인한 사용자가 있는지 체크
         if Auth.auth().currentUser != nil {
-            window.rootViewController = InviteCodeInputViewController()
+            window.rootViewController = BoardingPointSelectViewController()
         } else {
             window.rootViewController = LoginViewController()
         }

--- a/Carmu/Sources/SceneDelegate.swift
+++ b/Carmu/Sources/SceneDelegate.swift
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // 로그인한 사용자가 있는지 체크
         if Auth.auth().currentUser != nil {
-            window.rootViewController = BoardingPointSelectViewController()
+            window.rootViewController = SessionStartViewController()
         } else {
             window.rootViewController = LoginViewController()
         }

--- a/Carmu/Sources/Utils/CrewMakeUtil.swift
+++ b/Carmu/Sources/Utils/CrewMakeUtil.swift
@@ -68,12 +68,3 @@ final class CrewMakeUtil {
     }
 }
 
-// Preview
-import SwiftUI
-
-@available(iOS 13.0.0, *)
-struct BoringPointSelectViewPreview: PreviewProvider {
-    static var previews: some View {
-        BPSViewControllerRepresentable()
-    }
-}

--- a/Carmu/Sources/Utils/CrewMakeUtil.swift
+++ b/Carmu/Sources/Utils/CrewMakeUtil.swift
@@ -64,7 +64,70 @@ final class CrewMakeUtil {
             make.width.equalTo(12)
             make.height.equalTo(54)
         }
-        
         return colorLineView
+    }
+
+    static func stopoverPointSelectButton(address: String, _ isStartTime: Bool = true, time: Date) -> UIButton {
+        let button = UIButton()
+        let addressLabel = UILabel()
+        let timeLabel = UILabel()
+        let detailTimeLabel = UILabel()
+
+        addressLabel.text = address
+        timeLabel.text = isStartTime ? "출발" : "도착"
+        detailTimeLabel.text = Date.formattedDate(from: time, dateFormat: "aa hh:mm")
+
+        button.backgroundColor = UIColor.semantic.backgroundDefault
+        addressLabel.textColor = UIColor.semantic.textPrimary
+        timeLabel.textColor = UIColor.semantic.textPrimary
+        detailTimeLabel.textColor = UIColor.semantic.textPrimary
+        addressLabel.font = UIFont.carmuFont.headline1
+        timeLabel.font = UIFont.carmuFont.body1
+        detailTimeLabel.font = UIFont.carmuFont.subhead3
+
+        button.layer.cornerRadius = 8
+        button.layer.shadowColor = UIColor.theme.blue6?.cgColor
+        button.layer.shadowOffset = CGSize(width: 0, height: 0)
+        button.layer.shadowRadius = 8
+        button.layer.shadowOpacity = 0.2
+
+        button.addSubview(addressLabel)
+        button.addSubview(timeLabel)
+        button.addSubview(detailTimeLabel)
+
+        button.snp.makeConstraints { make in
+            make.height.equalTo(54)
+        }
+
+        addressLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(20)
+            make.trailing.greaterThanOrEqualTo(timeLabel.snp.leading).offset(-30)
+            make.width.equalTo(140)
+        }
+
+        timeLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalTo(detailTimeLabel.snp.leading).offset(-5)
+            make.width.equalTo(22)
+        }
+
+        detailTimeLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(20)
+            make.width.equalTo(74)
+        }
+
+        return button
+    }
+}
+
+// Preview
+import SwiftUI
+
+@available(iOS 13.0.0, *)
+struct BoringPointSelectViewPreview: PreviewProvider {
+    static var previews: some View {
+        BPSViewControllerRepresentable()
     }
 }

--- a/Carmu/Sources/Utils/CrewMakeUtil.swift
+++ b/Carmu/Sources/Utils/CrewMakeUtil.swift
@@ -67,4 +67,3 @@ final class CrewMakeUtil {
         return colorLineView
     }
 }
-

--- a/Carmu/Sources/Utils/CrewMakeUtil.swift
+++ b/Carmu/Sources/Utils/CrewMakeUtil.swift
@@ -61,8 +61,7 @@ final class CrewMakeUtil {
 
         purpleLineView.snp.makeConstraints { make in
             make.bottom.horizontalEdges.equalToSuperview()
-            make.width.equalTo(12)
-            make.height.equalTo(54)
+            make.width.height.equalTo(greenLineView)
         }
         return colorLineView
     }

--- a/Carmu/Sources/Utils/CrewMakeUtil.swift
+++ b/Carmu/Sources/Utils/CrewMakeUtil.swift
@@ -66,60 +66,6 @@ final class CrewMakeUtil {
         }
         return colorLineView
     }
-
-    static func stopoverPointSelectButton(address: String, _ isStartTime: Bool = true, time: Date) -> UIButton {
-        let button = UIButton()
-        let addressLabel = UILabel()
-        let timeLabel = UILabel()
-        let detailTimeLabel = UILabel()
-
-        addressLabel.text = address
-        timeLabel.text = isStartTime ? "출발" : "도착"
-        detailTimeLabel.text = Date.formattedDate(from: time, dateFormat: "aa hh:mm")
-
-        button.backgroundColor = UIColor.semantic.backgroundDefault
-        addressLabel.textColor = UIColor.semantic.textPrimary
-        timeLabel.textColor = UIColor.semantic.textPrimary
-        detailTimeLabel.textColor = UIColor.semantic.textPrimary
-        addressLabel.font = UIFont.carmuFont.headline1
-        timeLabel.font = UIFont.carmuFont.body1
-        detailTimeLabel.font = UIFont.carmuFont.subhead3
-
-        button.layer.cornerRadius = 8
-        button.layer.shadowColor = UIColor.theme.blue6?.cgColor
-        button.layer.shadowOffset = CGSize(width: 0, height: 0)
-        button.layer.shadowRadius = 8
-        button.layer.shadowOpacity = 0.2
-
-        button.addSubview(addressLabel)
-        button.addSubview(timeLabel)
-        button.addSubview(detailTimeLabel)
-
-        button.snp.makeConstraints { make in
-            make.height.equalTo(54)
-        }
-
-        addressLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.leading.equalToSuperview().inset(20)
-            make.trailing.greaterThanOrEqualTo(timeLabel.snp.leading).offset(-30)
-            make.width.equalTo(140)
-        }
-
-        timeLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.trailing.equalTo(detailTimeLabel.snp.leading).offset(-5)
-            make.width.equalTo(22)
-        }
-
-        detailTimeLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.trailing.equalToSuperview().inset(20)
-            make.width.equalTo(74)
-        }
-
-        return button
-    }
 }
 
 // Preview

--- a/Carmu/Sources/Utils/CrewMakeUtil.swift
+++ b/Carmu/Sources/Utils/CrewMakeUtil.swift
@@ -32,4 +32,39 @@ final class CrewMakeUtil {
         titleLabel.textColor = UIColor.semantic.accPrimary
         return titleLabel
     }
+
+    /**
+     장소 선택 시 나오는 컬러 라인을 리턴하는 함수
+     상단이 옥색, 하단이 보라색이다.
+     */
+    static func createColorLineView() -> UIView {
+        let colorLineView = UIView()
+        let greenLineView = UIView()
+        let purpleLineView = UIView()
+
+        colorLineView.backgroundColor = UIColor.semantic.backgroundThird
+        greenLineView.backgroundColor = UIColor.semantic.accSecondary
+        purpleLineView.backgroundColor = UIColor.semantic.accPrimary
+
+        colorLineView.layer.cornerRadius = 8
+        greenLineView.layer.cornerRadius = 8
+        purpleLineView.layer.cornerRadius = 8
+
+        colorLineView.addSubview(greenLineView)
+        colorLineView.addSubview(purpleLineView)
+
+        greenLineView.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+            make.width.equalTo(12)
+            make.height.equalTo(54)
+        }
+
+        purpleLineView.snp.makeConstraints { make in
+            make.bottom.horizontalEdges.equalToSuperview()
+            make.width.equalTo(12)
+            make.height.equalTo(54)
+        }
+        
+        return colorLineView
+    }
 }

--- a/Carmu/Sources/Utils/LargeSelectButton.swift
+++ b/Carmu/Sources/Utils/LargeSelectButton.swift
@@ -18,14 +18,14 @@ final class LargeSelectButton: UIButton {
         return imageView
     }()
 
-    let topTitleLabel: UILabel = {
+    private let topTitleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.carmuFont.headline1
         label.textColor = UIColor.semantic.textPrimary
         return label
     }()
 
-    let bottomTitleLabel: UILabel = {
+    private let bottomTitleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.carmuFont.subhead3
         label.textColor = UIColor.semantic.textPrimary

--- a/Carmu/Sources/Utils/StopoverSelectButton.swift
+++ b/Carmu/Sources/Utils/StopoverSelectButton.swift
@@ -64,18 +64,18 @@ final class StopoverSelectButton: UIButton {
         layer.shadowRadius = 8
         layer.shadowOpacity = 0.2
 
-        self.addressLabel.snp.makeConstraints { make in
+        addressLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalToSuperview().inset(20)
             make.width.equalTo(150)
         }
 
-        self.timeLabel.snp.makeConstraints { make in
+        timeLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalTo(detailTimeLabel.snp.leading).offset(-5)
         }
 
-        self.detailTimeLabel.snp.makeConstraints { make in
+        detailTimeLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(20)
         }

--- a/Carmu/Sources/Utils/StopoverSelectButton.swift
+++ b/Carmu/Sources/Utils/StopoverSelectButton.swift
@@ -1,0 +1,82 @@
+//
+//  StopoverSelectButton.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/2/23.
+//
+
+import UIKit
+
+final class StopoverSelectButton: UIButton {
+
+    private let addressLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor.semantic.textPrimary
+        label.font = UIFont.carmuFont.headline1
+
+        return label
+    }()
+
+    private let timeLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor.semantic.textPrimary
+        label.font = UIFont.carmuFont.body1
+
+        return label
+    }()
+
+    private let detailTimeLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor.semantic.textPrimary
+        label.font = UIFont.carmuFont.subhead3
+
+        return label
+    }()
+
+    // 버튼 컴포넌트의 기본 높이를 54로 지정
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: 54)
+    }
+
+    init(address: String, _ isStart: Bool = true, time: Date) {
+        super.init(frame: .zero)
+
+        addressLabel.text = address
+        timeLabel.text = isStart ? "출발" : "도착"
+        detailTimeLabel.text = Date.formattedDate(from: time, dateFormat: "aa hh:mm")
+
+        addSubview(addressLabel)
+        addSubview(timeLabel)
+        addSubview(detailTimeLabel)
+
+        backgroundColor = UIColor.semantic.backgroundDefault
+        layer.cornerRadius = 8
+        layer.shadowColor = UIColor.theme.blue6?.cgColor
+        layer.shadowOffset = CGSize(width: 0, height: 0)
+        layer.shadowRadius = 8
+        layer.shadowOpacity = 0.2
+
+        self.addressLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(20)
+            make.trailing.greaterThanOrEqualTo(timeLabel.snp.leading).offset(-30)
+            make.width.equalTo(140)
+        }
+
+        self.timeLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalTo(detailTimeLabel.snp.leading).offset(-5)
+            make.width.equalTo(22)
+        }
+
+        self.detailTimeLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(20)
+            make.width.equalTo(74)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Carmu/Sources/Utils/StopoverSelectButton.swift
+++ b/Carmu/Sources/Utils/StopoverSelectButton.swift
@@ -67,20 +67,17 @@ final class StopoverSelectButton: UIButton {
         self.addressLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalToSuperview().inset(20)
-            make.trailing.greaterThanOrEqualTo(timeLabel.snp.leading).offset(-30)
-            make.width.equalTo(140)
+            make.width.equalTo(150)
         }
 
         self.timeLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalTo(detailTimeLabel.snp.leading).offset(-5)
-            make.width.equalTo(24)
         }
 
         self.detailTimeLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(20)
-            make.width.equalTo(76)
         }
     }
 

--- a/Carmu/Sources/Utils/StopoverSelectButton.swift
+++ b/Carmu/Sources/Utils/StopoverSelectButton.swift
@@ -66,17 +66,46 @@ final class StopoverSelectButton: UIButton {
         self.timeLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalTo(detailTimeLabel.snp.leading).offset(-5)
-            make.width.equalTo(22)
+            make.width.equalTo(24)
         }
 
         self.detailTimeLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(20)
-            make.width.equalTo(74)
+            make.width.equalTo(76)
         }
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - 버튼을 탭할 시 외형 변경에 필요한 메서드
+extension StopoverSelectButton {
+    // 선택한 버튼의 외관을 변경
+    func setSelectedButtonAppearance() {
+        backgroundColor = UIColor.theme.blue6
+        addressLabel.textColor = UIColor.semantic.textSecondary
+        timeLabel.textColor = UIColor.semantic.textSecondary
+        detailTimeLabel.textColor = UIColor.semantic.textSecondary
+    }
+
+    // 선택한 버튼의 외관을 복구
+    func resetButtonAppearance() {
+        backgroundColor = UIColor.semantic.backgroundDefault
+        addressLabel.textColor = UIColor.semantic.textPrimary
+        timeLabel.textColor = UIColor.semantic.textPrimary
+        detailTimeLabel.textColor = UIColor.semantic.textPrimary
+    }
+}
+
+// Preview
+import SwiftUI
+
+@available(iOS 13.0.0, *)
+struct BoringPointSelectViewPreview: PreviewProvider {
+    static var previews: some View {
+        BPSViewControllerRepresentable()
     }
 }

--- a/Carmu/Sources/Utils/StopoverSelectButton.swift
+++ b/Carmu/Sources/Utils/StopoverSelectButton.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+/**
+ 경유지 설정 화면에서 선택하는 버튼.
+ */
 final class StopoverSelectButton: UIButton {
 
     private let addressLabel: UILabel = {
@@ -38,6 +41,11 @@ final class StopoverSelectButton: UIButton {
         return CGSize(width: UIView.noIntrinsicMetric, height: 54)
     }
 
+    /**
+     address: 출발지의 대표명
+     isStart: 도착지라면 false(기본값 true)
+     time: 출발 또는 도착 시간
+     */
     init(address: String, _ isStart: Bool = true, time: Date) {
         super.init(frame: .zero)
 

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -21,19 +21,17 @@ final class BoardingPointSelectView: UIView {
     lazy var selectTableStack = UIStackView()
     lazy var colorLineView = CrewMakeUtil.createColorLineView()
     var customTableView = UIStackView()
-    lazy var customTableVieWCell: [UIButton] = [
-        StopoverSelectButton(
-            address: "출발지 주소",
-            time: Date()
-        ),
-        StopoverSelectButton(address: "경유지 주소", time: Date()),
-        StopoverSelectButton(address: "경유지 2주소 입니다", time: Date()),
-        StopoverSelectButton(
-            address: "도착지 주소",
-            false,
-            time: Date()
-        )
-    ]
+    lazy var customTableVieWCell: [StopoverSelectButton] = {
+        var buttons: [StopoverSelectButton] = []
+
+        for (index, address) in ["출발지 주소", "경유지 주소", "경유지 2주소 입니다", "도착지 주소"].enumerated() {
+            let button = StopoverSelectButton(address: address, time: Date())
+            button.tag = index
+            buttons.append(button)
+        }
+
+        return buttons
+    }()
 
     lazy var nextButton: UIButton = {
         let button = UIButton()

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BoardingPointSelectView: UIView {
+final class BoardingPointSelectView: UIView {
 
     private lazy var firstLineTitleStack = UIStackView()
     private lazy var secondLineTitleStack = UIStackView()
@@ -30,6 +30,16 @@ class BoardingPointSelectView: UIView {
         )
         button.layer.cornerRadius = 30
         return button
+    }()
+
+    lazy var selectTableStack = UIStackView()
+
+    lazy var colorLineView = CrewMakeUtil.createColorLineView()
+
+    lazy var customTableView: UIStackView = {
+        let stack = UIStackView()
+        stack.layer.borderWidth = 1
+        return stack
     }()
 
     override init(frame: CGRect) {
@@ -58,9 +68,13 @@ class BoardingPointSelectView: UIView {
         secondLineTitleStack.addArrangedSubview(titleLabel4)
         secondLineTitleStack.addArrangedSubview(titleLabel5)
 
+        selectTableStack.addArrangedSubview(colorLineView)
+        selectTableStack.addArrangedSubview(customTableView)
+
         addSubview(firstLineTitleStack)
         addSubview(secondLineTitleStack)
         addSubview(nextButton)
+        addSubview(selectTableStack)
     }
 
     private func setAutoLayout() {
@@ -73,6 +87,19 @@ class BoardingPointSelectView: UIView {
         secondLineTitleStack.snp.makeConstraints { make in
             make.top.equalTo(firstLineTitleStack.snp.bottom)
             make.leading.equalToSuperview().inset(20)
+        }
+
+        selectTableStack.snp.makeConstraints { make in
+            make.bottom.equalTo(nextButton.snp.top).offset(-60)
+            make.top.equalTo(secondLineTitleStack.snp.bottom).offset(66)
+            make.top.greaterThanOrEqualTo(secondLineTitleStack.snp.bottom).offset(50)
+            make.bottom.greaterThanOrEqualTo(nextButton.snp.top).offset(50)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+
+        colorLineView.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview()
+            make.width.equalTo(12)
         }
 
         nextButton.snp.makeConstraints { make in

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -1,0 +1,94 @@
+//
+//  BoardingPointSelectView.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/2/23.
+//
+
+import UIKit
+
+class BoardingPointSelectView: UIView {
+
+    private lazy var firstLineTitleStack = UIStackView()
+    private lazy var secondLineTitleStack = UIStackView()
+
+    private lazy var titleLabel1 = CrewMakeUtil.defalutTitle(titleText: "탑승하시는 ")
+    private lazy var titleLabel2 = CrewMakeUtil.accPrimaryTitle(titleText: "장소")
+    private lazy var titleLabel3 = CrewMakeUtil.defalutTitle(titleText: "를")
+    private lazy var titleLabel4 = CrewMakeUtil.accPrimaryTitle(titleText: "선택")
+    private lazy var titleLabel5 = CrewMakeUtil.defalutTitle(titleText: "해주세요")
+
+    lazy var nextButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("카풀 시작하기", for: .normal)
+        button.backgroundColor = UIColor.semantic.accPrimary
+        button.titleLabel?.font = UIFont.carmuFont.headline2
+        button.setTitleColor(UIColor.semantic.textSecondary, for: .normal)
+        button.setBackgroundImage(
+            UIImage(color: UIColor.semantic.textSecondary ?? .white),
+            for: .highlighted
+        )
+        button.layer.cornerRadius = 30
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func draw(_ rect: CGRect) {
+        setupViews()
+        setAutoLayout()
+    }
+
+    private func setupViews() {
+        firstLineTitleStack.axis = .horizontal
+        firstLineTitleStack.alignment = .center
+        secondLineTitleStack.axis = .horizontal
+        secondLineTitleStack.alignment = .center
+
+        firstLineTitleStack.addArrangedSubview(titleLabel1)
+        firstLineTitleStack.addArrangedSubview(titleLabel2)
+        firstLineTitleStack.addArrangedSubview(titleLabel3)
+
+        secondLineTitleStack.addArrangedSubview(titleLabel4)
+        secondLineTitleStack.addArrangedSubview(titleLabel5)
+
+        addSubview(firstLineTitleStack)
+        addSubview(secondLineTitleStack)
+        addSubview(nextButton)
+    }
+
+    private func setAutoLayout() {
+        firstLineTitleStack.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(78)
+            make.leading.equalToSuperview().inset(20)
+            make.bottom.equalTo(secondLineTitleStack.snp.top)
+        }
+
+        secondLineTitleStack.snp.makeConstraints { make in
+            make.top.equalTo(firstLineTitleStack.snp.bottom)
+            make.leading.equalToSuperview().inset(20)
+        }
+
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(60)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(60)
+        }
+    }
+}
+
+// Preview
+import SwiftUI
+
+@available(iOS 13.0.0, *)
+struct BoardingPointSelectViewPreview: PreviewProvider {
+    static var previews: some View {
+        BPSViewControllerRepresentable()
+    }
+}

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -18,6 +18,23 @@ final class BoardingPointSelectView: UIView {
     private lazy var titleLabel4 = CrewMakeUtil.accPrimaryTitle(titleText: "선택")
     private lazy var titleLabel5 = CrewMakeUtil.defalutTitle(titleText: "해주세요")
 
+    lazy var selectTableStack = UIStackView()
+    lazy var colorLineView = CrewMakeUtil.createColorLineView()
+    var customTableView = UIStackView()
+    lazy var customTableVieWCell: [UIButton] = [
+        CrewMakeUtil.stopoverPointSelectButton(
+            address: "출발지 주소",
+            time: Date()
+        ),
+        CrewMakeUtil.stopoverPointSelectButton(address: "경유지 주소", time: Date()),
+        CrewMakeUtil.stopoverPointSelectButton(address: "경유지 2주소 입니다", time: Date()),
+        CrewMakeUtil.stopoverPointSelectButton(
+            address: "도착지 주소",
+            false,
+            time: Date()
+        )
+    ]
+
     lazy var nextButton: UIButton = {
         let button = UIButton()
         button.setTitle("카풀 시작하기", for: .normal)
@@ -30,16 +47,6 @@ final class BoardingPointSelectView: UIView {
         )
         button.layer.cornerRadius = 30
         return button
-    }()
-
-    lazy var selectTableStack = UIStackView()
-
-    lazy var colorLineView = CrewMakeUtil.createColorLineView()
-
-    lazy var customTableView: UIStackView = {
-        let stack = UIStackView()
-        stack.layer.borderWidth = 1
-        return stack
     }()
 
     override init(frame: CGRect) {
@@ -60,6 +67,15 @@ final class BoardingPointSelectView: UIView {
         firstLineTitleStack.alignment = .center
         secondLineTitleStack.axis = .horizontal
         secondLineTitleStack.alignment = .center
+        selectTableStack.axis = .horizontal
+        selectTableStack.spacing = 12
+        customTableView.axis = .vertical
+        customTableView.distribution = .equalSpacing
+
+        addSubview(firstLineTitleStack)
+        addSubview(secondLineTitleStack)
+        addSubview(nextButton)
+        addSubview(selectTableStack)
 
         firstLineTitleStack.addArrangedSubview(titleLabel1)
         firstLineTitleStack.addArrangedSubview(titleLabel2)
@@ -71,35 +87,42 @@ final class BoardingPointSelectView: UIView {
         selectTableStack.addArrangedSubview(colorLineView)
         selectTableStack.addArrangedSubview(customTableView)
 
-        addSubview(firstLineTitleStack)
-        addSubview(secondLineTitleStack)
-        addSubview(nextButton)
-        addSubview(selectTableStack)
+        for element in customTableVieWCell {
+            customTableView.addArrangedSubview(element)
+        }
     }
 
     private func setAutoLayout() {
         firstLineTitleStack.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(78)
-            make.leading.equalToSuperview().inset(20)
             make.bottom.equalTo(secondLineTitleStack.snp.top)
+            make.leading.equalToSuperview().inset(20)
+            make.height.equalTo(28)
         }
 
         secondLineTitleStack.snp.makeConstraints { make in
             make.top.equalTo(firstLineTitleStack.snp.bottom)
             make.leading.equalToSuperview().inset(20)
+            make.height.equalTo(28)
         }
 
         selectTableStack.snp.makeConstraints { make in
-            make.bottom.equalTo(nextButton.snp.top).offset(-60)
             make.top.equalTo(secondLineTitleStack.snp.bottom).offset(66)
             make.top.greaterThanOrEqualTo(secondLineTitleStack.snp.bottom).offset(50)
+            make.bottom.equalTo(nextButton.snp.top).offset(-60)
             make.bottom.greaterThanOrEqualTo(nextButton.snp.top).offset(50)
             make.horizontalEdges.equalToSuperview().inset(20)
         }
 
         colorLineView.snp.makeConstraints { make in
-            make.verticalEdges.equalToSuperview()
+            make.verticalEdges.leading.equalToSuperview()
+            make.trailing.equalTo(customTableView.snp.leading).offset(-12)
             make.width.equalTo(12)
+        }
+
+        customTableView.snp.makeConstraints { make in
+            make.verticalEdges.trailing.equalToSuperview()
+            make.leading.equalTo(colorLineView.snp.trailing).offset(12)
         }
 
         nextButton.snp.makeConstraints { make in

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -36,7 +36,7 @@ final class BoardingPointSelectView: UIView {
     lazy var nextButton: UIButton = {
         let button = UIButton()
         button.setTitle("카풀 시작하기", for: .normal)
-        button.backgroundColor = UIColor.semantic.accPrimary
+        button.backgroundColor = UIColor.semantic.backgroundThird
         button.titleLabel?.font = UIFont.carmuFont.headline2
         button.setTitleColor(UIColor.semantic.textSecondary, for: .normal)
         button.setBackgroundImage(
@@ -44,6 +44,8 @@ final class BoardingPointSelectView: UIView {
             for: .highlighted
         )
         button.layer.cornerRadius = 30
+        button.isEnabled = false
+
         return button
     }()
 

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -22,13 +22,13 @@ final class BoardingPointSelectView: UIView {
     lazy var colorLineView = CrewMakeUtil.createColorLineView()
     var customTableView = UIStackView()
     lazy var customTableVieWCell: [UIButton] = [
-        CrewMakeUtil.stopoverPointSelectButton(
+        StopoverSelectButton(
             address: "출발지 주소",
             time: Date()
         ),
-        CrewMakeUtil.stopoverPointSelectButton(address: "경유지 주소", time: Date()),
-        CrewMakeUtil.stopoverPointSelectButton(address: "경유지 2주소 입니다", time: Date()),
-        CrewMakeUtil.stopoverPointSelectButton(
+        StopoverSelectButton(address: "경유지 주소", time: Date()),
+        StopoverSelectButton(address: "경유지 2주소 입니다", time: Date()),
+        StopoverSelectButton(
             address: "도착지 주소",
             false,
             time: Date()

--- a/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/BoardingPointSelectView.swift
@@ -24,7 +24,7 @@ final class BoardingPointSelectView: UIView {
     lazy var customTableVieWCell: [StopoverSelectButton] = {
         var buttons: [StopoverSelectButton] = []
 
-        for (index, address) in ["출발지 주소", "경유지 주소", "경유지 2주소 입니다", "도착지 주소"].enumerated() {
+        for (index, address) in ["출발지 주소", "경유지 주소", "경유지 2주소 입니다dddfdfd", "도착지 주소"].enumerated() {
             let button = StopoverSelectButton(address: address, time: Date())
             button.tag = index
             buttons.append(button)
@@ -97,20 +97,16 @@ final class BoardingPointSelectView: UIView {
             make.top.equalTo(safeAreaLayoutGuide).offset(78)
             make.bottom.equalTo(secondLineTitleStack.snp.top)
             make.leading.equalToSuperview().inset(20)
-            make.height.equalTo(28)
         }
 
         secondLineTitleStack.snp.makeConstraints { make in
             make.top.equalTo(firstLineTitleStack.snp.bottom)
             make.leading.equalToSuperview().inset(20)
-            make.height.equalTo(28)
         }
 
         selectTableStack.snp.makeConstraints { make in
             make.top.equalTo(secondLineTitleStack.snp.bottom).offset(66)
-            make.top.greaterThanOrEqualTo(secondLineTitleStack.snp.bottom).offset(50)
             make.bottom.equalTo(nextButton.snp.top).offset(-60)
-            make.bottom.greaterThanOrEqualTo(nextButton.snp.top).offset(50)
             make.horizontalEdges.equalToSuperview().inset(20)
         }
 


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Feat: 새로운 기능을 추가
- [x] Design: CSS 등 사용자 UI 디자인 변경

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

탑승지 설정 화면 구현을 했습니다.
테이블 뷰처럼 디자인이 되어 있지만, 테이블뷰 높이 설정이 어려운 관계로,
버튼을 커스텀하여 테이블뷰처럼 만들어놓았습니다.

StopoverSelectButton이 Cell의 역할을 합니다.
동승자 크루 생성 과정에 필요한 껍데기 만들기는 끝났습니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: N/A

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #145 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
![Simulator Screen Recording - iPhone 15 Pro - 2023-11-02 at 12 31 05](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/f02865ef-d7c1-4bb8-9f48-b121fca40a89)
