### PR TITLE
[Feat] 크루 생성 - 경유지 설정 화면 구현(운전자)

### DIFF
--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		C9D04C6E2AFB81B2007E615B /* StopoverPointSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */; };
 		C9D04C712AFB81F9007E615B /* StopoverPointSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */; };
 		C9D04C732AFC65BE007E615B /* StopoverPointAddButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */; };
+		C9D04C752AFCD315007E615B /* SelectAddressButtonProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C742AFCD315007E615B /* SelectAddressButtonProtocol.swift */; };
 		C9D8E4DC2AF4814E007570EE /* TimeSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */; };
 		C9D8E4DE2AF48172007570EE /* TimeSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */; };
 		C9D8E4E02AF482B9007570EE /* RepeatDaySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */; };
@@ -199,6 +200,7 @@
 		C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointSelectView.swift; sourceTree = "<group>"; };
 		C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointSelectViewController.swift; sourceTree = "<group>"; };
 		C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointAddButtonView.swift; sourceTree = "<group>"; };
+		C9D04C742AFCD315007E615B /* SelectAddressButtonProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAddressButtonProtocol.swift; sourceTree = "<group>"; };
 		C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectViewController.swift; sourceTree = "<group>"; };
 		C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectView.swift; sourceTree = "<group>"; };
 		C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatDaySelectViewController.swift; sourceTree = "<group>"; };
@@ -574,6 +576,8 @@
 			children = (
 				C9F43BD12AF227B100BAA0E3 /* LargeSelectButton.swift */,
 				C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */,
+				C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */,
+				C9D04C742AFCD315007E615B /* SelectAddressButtonProtocol.swift */,
 				C9F43BE02AF3430C00BAA0E3 /* StopoverSelectButton.swift */,
 				C954621D2AF77D9D004C4F6D /* NextButton.swift */,
 				C954621F2AF77FF8004C4F6D /* DaySelectButton.swift */,
@@ -614,7 +618,6 @@
 			isa = PBXGroup;
 			children = (
 				C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */,
-				C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */,
 			);
 			path = StopoverPointSelect;
 			sourceTree = "<group>";
@@ -775,6 +778,7 @@
 				B8D73AC12AD29D6E00D211DE /* PrivacyView.swift in Sources */,
 				B8D73ABF2AD2914200D211DE /* SettingsView.swift in Sources */,
 				C9F43BD22AF227B100BAA0E3 /* LargeSelectButton.swift in Sources */,
+				C9D04C752AFCD315007E615B /* SelectAddressButtonProtocol.swift in Sources */,
 				C9D04C712AFB81F9007E615B /* StopoverPointSelectViewController.swift in Sources */,
 				C93116722AF3B5190014E702 /* SelectAddressViewController.swift in Sources */,
 				B8D73AC32AD2FBE600D211DE /* InquiryView.swift in Sources */,

--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		C9D04C6B2AFB7864007E615B /* AddressSelectButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */; };
 		C9D04C6E2AFB81B2007E615B /* StopoverPointSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */; };
 		C9D04C712AFB81F9007E615B /* StopoverPointSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */; };
+		C9D04C732AFC65BE007E615B /* StopoverPointAddButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */; };
 		C9D8E4DC2AF4814E007570EE /* TimeSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */; };
 		C9D8E4DE2AF48172007570EE /* TimeSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */; };
 		C9D8E4E02AF482B9007570EE /* RepeatDaySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */; };
@@ -197,6 +198,7 @@
 		C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSelectButtonView.swift; sourceTree = "<group>"; };
 		C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointSelectView.swift; sourceTree = "<group>"; };
 		C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointSelectViewController.swift; sourceTree = "<group>"; };
+		C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointAddButtonView.swift; sourceTree = "<group>"; };
 		C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectViewController.swift; sourceTree = "<group>"; };
 		C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectView.swift; sourceTree = "<group>"; };
 		C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatDaySelectViewController.swift; sourceTree = "<group>"; };
@@ -612,6 +614,7 @@
 			isa = PBXGroup;
 			children = (
 				C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */,
+				C9D04C722AFC65BE007E615B /* StopoverPointAddButtonView.swift */,
 			);
 			path = StopoverPointSelect;
 			sourceTree = "<group>";
@@ -781,6 +784,7 @@
 				C9F43BDD2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift in Sources */,
 				B8376E3C2AF936DB007F1E0A /* CrewInfoNoCrewView.swift in Sources */,
 				C9D04C6B2AFB7864007E615B /* AddressSelectButtonView.swift in Sources */,
+				C9D04C732AFC65BE007E615B /* StopoverPointAddButtonView.swift in Sources */,
 				B83E23F02AF3F3600048ED9A /* ProfileImageColorCollectionViewCell.swift in Sources */,
 				B8DD15EC2AD6CFBF00685E48 /* GiftCardCollectionViewCell.swift in Sources */,
 				BF9BCFFD2ACE458D009DAECD /* MyPageView.swift in Sources */,

--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		C9D04C652AF89953007E615B /* RightNavigationBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C642AF89953007E615B /* RightNavigationBarButton.swift */; };
 		C9D04C692AF9D312007E615B /* DayOfWeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C682AF9D312007E615B /* DayOfWeek.swift */; };
 		C9D04C6B2AFB7864007E615B /* AddressSelectButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */; };
+		C9D04C6E2AFB81B2007E615B /* StopoverPointSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */; };
+		C9D04C712AFB81F9007E615B /* StopoverPointSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */; };
 		C9D8E4DC2AF4814E007570EE /* TimeSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */; };
 		C9D8E4DE2AF48172007570EE /* TimeSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */; };
 		C9D8E4E02AF482B9007570EE /* RepeatDaySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */; };
@@ -193,6 +195,8 @@
 		C9D04C642AF89953007E615B /* RightNavigationBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightNavigationBarButton.swift; sourceTree = "<group>"; };
 		C9D04C682AF9D312007E615B /* DayOfWeek.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeek.swift; sourceTree = "<group>"; };
 		C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSelectButtonView.swift; sourceTree = "<group>"; };
+		C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointSelectView.swift; sourceTree = "<group>"; };
+		C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverPointSelectViewController.swift; sourceTree = "<group>"; };
 		C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectViewController.swift; sourceTree = "<group>"; };
 		C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectView.swift; sourceTree = "<group>"; };
 		C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatDaySelectViewController.swift; sourceTree = "<group>"; };
@@ -481,6 +485,7 @@
 			isa = PBXGroup;
 			children = (
 				C95462122AF74BFC004C4F6D /* StartEndPointSelect */,
+				C9D04C6F2AFB81E1007E615B /* StopoverPointSelect */,
 				C93116652AF382260014E702 /* StopoverPointCheckViewController.swift */,
 				C95462132AF74C0B004C4F6D /* TimeSelect */,
 				C95462212AF7B2B0004C4F6D /* RepeatDaySelect */,
@@ -504,6 +509,7 @@
 			children = (
 				C95462112AF74BEA004C4F6D /* StartEndPointSelect */,
 				C93116672AF3822D0014E702 /* StopoverPointCheckView.swift */,
+				C9D04C6C2AFB8190007E615B /* StopoverPointSelect */,
 				C95462102AF74BD4004C4F6D /* TimeSelect */,
 				C95462242AF7B300004C4F6D /* RepeatDaySelect */,
 				C9D8E4E32AF484B3007570EE /* FinalConfirmView.swift */,
@@ -600,6 +606,22 @@
 				C954621C2AF77D52004C4F6D /* ButtonComponent */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		C9D04C6C2AFB8190007E615B /* StopoverPointSelect */ = {
+			isa = PBXGroup;
+			children = (
+				C9D04C6D2AFB81B2007E615B /* StopoverPointSelectView.swift */,
+			);
+			path = StopoverPointSelect;
+			sourceTree = "<group>";
+		};
+		C9D04C6F2AFB81E1007E615B /* StopoverPointSelect */ = {
+			isa = PBXGroup;
+			children = (
+				C9D04C702AFB81F9007E615B /* StopoverPointSelectViewController.swift */,
+			);
+			path = StopoverPointSelect;
 			sourceTree = "<group>";
 		};
 		C9F43BC72AF214CB00BAA0E3 /* CrewMake */ = {
@@ -739,6 +761,7 @@
 				BFFA10B22AE61012003CE661 /* NoticeLateViewController.swift in Sources */,
 				C93116662AF382260014E702 /* StopoverPointCheckViewController.swift in Sources */,
 				C9D8E4E02AF482B9007570EE /* RepeatDaySelectViewController.swift in Sources */,
+				C9D04C6E2AFB81B2007E615B /* StopoverPointSelectView.swift in Sources */,
 				B8EECEA22ACD6598004D310C /* KeychainItem.swift in Sources */,
 				C95462202AF77FF8004C4F6D /* DaySelectButton.swift in Sources */,
 				C9F43BCE2AF2155400BAA0E3 /* PositionSelectView.swift in Sources */,
@@ -749,6 +772,7 @@
 				B8D73AC12AD29D6E00D211DE /* PrivacyView.swift in Sources */,
 				B8D73ABF2AD2914200D211DE /* SettingsView.swift in Sources */,
 				C9F43BD22AF227B100BAA0E3 /* LargeSelectButton.swift in Sources */,
+				C9D04C712AFB81F9007E615B /* StopoverPointSelectViewController.swift in Sources */,
 				C93116722AF3B5190014E702 /* SelectAddressViewController.swift in Sources */,
 				B8D73AC32AD2FBE600D211DE /* InquiryView.swift in Sources */,
 				C93116762AF3B5F00014E702 /* SelectAddressTableViewCell.swift in Sources */,

--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		C9C7C1212ADE25590016DE13 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7C1202ADE25590016DE13 /* String+Extension.swift */; };
 		C9D04C652AF89953007E615B /* RightNavigationBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C642AF89953007E615B /* RightNavigationBarButton.swift */; };
 		C9D04C692AF9D312007E615B /* DayOfWeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C682AF9D312007E615B /* DayOfWeek.swift */; };
+		C9D04C6B2AFB7864007E615B /* AddressSelectButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */; };
 		C9D8E4DC2AF4814E007570EE /* TimeSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */; };
 		C9D8E4DE2AF48172007570EE /* TimeSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */; };
 		C9D8E4E02AF482B9007570EE /* RepeatDaySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */; };
@@ -191,6 +192,7 @@
 		C9C7C1202ADE25590016DE13 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		C9D04C642AF89953007E615B /* RightNavigationBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightNavigationBarButton.swift; sourceTree = "<group>"; };
 		C9D04C682AF9D312007E615B /* DayOfWeek.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeek.swift; sourceTree = "<group>"; };
+		C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSelectButtonView.swift; sourceTree = "<group>"; };
 		C9D8E4DB2AF4814E007570EE /* TimeSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectViewController.swift; sourceTree = "<group>"; };
 		C9D8E4DD2AF48172007570EE /* TimeSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectView.swift; sourceTree = "<group>"; };
 		C9D8E4DF2AF482B9007570EE /* RepeatDaySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatDaySelectViewController.swift; sourceTree = "<group>"; };
@@ -563,6 +565,7 @@
 			isa = PBXGroup;
 			children = (
 				C9F43BD12AF227B100BAA0E3 /* LargeSelectButton.swift */,
+				C9D04C6A2AFB7864007E615B /* AddressSelectButtonView.swift */,
 				C9F43BE02AF3430C00BAA0E3 /* StopoverSelectButton.swift */,
 				C954621D2AF77D9D004C4F6D /* NextButton.swift */,
 				C954621F2AF77FF8004C4F6D /* DaySelectButton.swift */,
@@ -753,6 +756,7 @@
 				C9F43BDB2AF2700400BAA0E3 /* InviteCodeInputView.swift in Sources */,
 				C9F43BDD2AF2C06C00BAA0E3 /* BoardingPointSelectViewController.swift in Sources */,
 				B8376E3C2AF936DB007F1E0A /* CrewInfoNoCrewView.swift in Sources */,
+				C9D04C6B2AFB7864007E615B /* AddressSelectButtonView.swift in Sources */,
 				B83E23F02AF3F3600048ED9A /* ProfileImageColorCollectionViewCell.swift in Sources */,
 				B8DD15EC2AD6CFBF00685E48 /* GiftCardCollectionViewCell.swift in Sources */,
 				BF9BCFFD2ACE458D009DAECD /* MyPageView.swift in Sources */,

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
@@ -13,7 +13,7 @@ final class StartEndPointSelectViewController: UIViewController {
 
     private var startPointAddress: String? {
         didSet {
-            startEndPointSelectView.startPointView.selectPointButton.setTitle(
+            startEndPointSelectView.startPointView.button.setTitle(
                 "     " + (startPointAddress ?? ""),
                 for: .normal
             )
@@ -25,7 +25,7 @@ final class StartEndPointSelectViewController: UIViewController {
     }
     private var endPointAddress: String? {
         didSet {
-            startEndPointSelectView.endPointView.selectPointButton.setTitle(
+            startEndPointSelectView.endPointView.button.setTitle(
                 "     " + (endPointAddress ?? ""),
                 for: .normal
             )
@@ -40,12 +40,12 @@ final class StartEndPointSelectViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = UIColor.semantic.backgroundDefault
 
-        startEndPointSelectView.startPointView.selectPointButton.addTarget(
+        startEndPointSelectView.startPointView.button.addTarget(
             self,
             action: #selector(findAddressButtonTapped),
             for: .touchUpInside
         )
-        startEndPointSelectView.endPointView.selectPointButton.addTarget(
+        startEndPointSelectView.endPointView.button.addTarget(
             self,
             action: #selector(findAddressButtonTapped),
             for: .touchUpInside

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
@@ -13,7 +13,7 @@ final class StartEndPointSelectViewController: UIViewController {
 
     private var startPointAddress: String? {
         didSet {
-            startEndPointSelectView.startPointButton.setTitle(
+            startEndPointSelectView.startPointView.selectPointButton.setTitle(
                 "     " + (startPointAddress ?? ""),
                 for: .normal
             )
@@ -25,8 +25,8 @@ final class StartEndPointSelectViewController: UIViewController {
     }
     private var endPointAddress: String? {
         didSet {
-            startEndPointSelectView.endPointButton.setTitle(
-                "     " + (startPointAddress ?? ""),
+            startEndPointSelectView.endPointView.selectPointButton.setTitle(
+                "     " + (endPointAddress ?? ""),
                 for: .normal
             )
             if startPointAddress != nil {
@@ -40,12 +40,12 @@ final class StartEndPointSelectViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = UIColor.semantic.backgroundDefault
 
-        startEndPointSelectView.startPointButton.addTarget(
+        startEndPointSelectView.startPointView.selectPointButton.addTarget(
             self,
             action: #selector(findAddressButtonTapped),
             for: .touchUpInside
         )
-        startEndPointSelectView.endPointButton.addTarget(
+        startEndPointSelectView.endPointView.selectPointButton.addTarget(
             self,
             action: #selector(findAddressButtonTapped),
             for: .touchUpInside

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
@@ -38,6 +38,8 @@ extension StopoverPointCheckViewController {
 
     @objc private func yesButtonTapped() {
         // TODO: - 경유지 설정 화면으로 이동 구현 필요
+        let viewController = StopoverPointSelectViewController()
+        navigationController?.pushViewController(viewController, animated: true)
     }
 
     @objc private func noButtonTapped() {

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -22,7 +22,21 @@ final class StopoverPointSelectViewController: UIViewController {
             action: #selector(nextButtonTapped),
             for: .touchUpInside
         )
-        stopoverPointSelectView.stopoverAddButton.button.addTarget(self, action: #selector(addPointButtonTapped), for: .touchUpInside)
+        stopoverPointSelectView.stopoverAddButton.button.addTarget(
+            self,
+            action: #selector(addPointButtonTapped),
+            for: .touchUpInside
+        )
+        stopoverPointSelectView.stopover2.xButton.addTarget(
+            self,
+            action: #selector(deletePointButtonTapped),
+            for: .touchUpInside
+        )
+        stopoverPointSelectView.stopover3.xButton.addTarget(
+            self,
+            action: #selector(deletePointButtonTapped),
+            for: .touchUpInside
+        )
         view.addSubview(stopoverPointSelectView)
         stopoverPointSelectView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -42,6 +56,7 @@ extension StopoverPointSelectViewController {
             }
             stopoverPointSelectView.stopover2.label.isHidden = false
             stopoverPointSelectView.stopover2.button.isHidden = false
+            stopoverPointSelectView.stopover2.xButton.isHidden = false
             stopoverCount += 1
         } else {
             stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
@@ -52,27 +67,43 @@ extension StopoverPointSelectViewController {
             stopoverPointSelectView.stopoverAddButton.isHidden = true
             stopoverPointSelectView.stopover3.label.isHidden = false
             stopoverPointSelectView.stopover3.button.isHidden = false
+            stopoverPointSelectView.stopover3.xButton.isHidden = false
             stopoverCount += 1
         }
     }
 
-    @objc private func findAddressButtonTapped(_ sender: UIButton) {
-        let detailViewController = SelectAddressViewController()
-        let navigation = UINavigationController(rootViewController: detailViewController)
-
-        detailViewController.selectAddressView.headerTitleLabel.text = {
-            if sender.titleLabel?.text == "     출발지 검색" {
-                return "출발지 주소 설정"
-            } else {
-                return "도착지 주소 설정"
+    @objc private func deletePointButtonTapped() {
+        if stopoverCount == 3 {
+            stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
+                make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
+                make.bottom.equalTo(stopoverPointSelectView.stopover3).offset(30)
+                make.leading.equalTo(stopoverPointSelectView).inset(20)
             }
-        }()
+            stopoverPointSelectView.stopover3.label.isHidden = true
+            stopoverPointSelectView.stopover3.button.isHidden = true
+            stopoverPointSelectView.stopover3.xButton.isHidden = true
+            stopoverPointSelectView.stopoverAddButton.isHidden = false
+            stopoverCount -= 1
+        } else {
+            stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
+                make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
+                make.bottom.equalTo(stopoverPointSelectView.stopover2).offset(30)
+                make.leading.equalToSuperview().inset(20)
+            }
+            stopoverPointSelectView.stopover2.label.isHidden = true
+            stopoverPointSelectView.stopover2.button.isHidden = true
+            stopoverPointSelectView.stopover2.xButton.isHidden = true
+            stopoverCount -= 1
+        }
+    }
 
+    @objc private func findAddressButtonTapped(_ sender: UIButton) {
+        let detailViewController = SelectDetailPointMapViewController(selectAddressModel: SelectAddressDTO())
 //        detailViewController.addressSelectionHandler = { [weak self] addressDTO in
 //            // TODO: 다음 작업에 Model에 값 적재하는 로직 구현 필요
 //
 //        }
-        present(navigation, animated: true)
+        present(detailViewController, animated: true)
     }
 
     @objc private func nextButtonTapped() {

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class StopoverPointSelectViewController: UIViewController {
 
     private let stopoverPointSelectView = StopoverPointSelectView()
+    private var stopoverCount = 1
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,6 +22,7 @@ final class StopoverPointSelectViewController: UIViewController {
             action: #selector(nextButtonTapped),
             for: .touchUpInside
         )
+        stopoverPointSelectView.stopoverAddButton.button.addTarget(self, action: #selector(addPointButtonTapped), for: .touchUpInside)
         view.addSubview(stopoverPointSelectView)
         stopoverPointSelectView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -30,6 +32,29 @@ final class StopoverPointSelectViewController: UIViewController {
 
 // MARK: - @objc Method
 extension StopoverPointSelectViewController {
+
+    @objc private func addPointButtonTapped() {
+        if stopoverCount == 1 {
+            stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
+                make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
+                make.bottom.equalTo(stopoverPointSelectView.stopover3).offset(30)
+                make.leading.equalTo(stopoverPointSelectView).inset(20)
+            }
+            stopoverPointSelectView.stopover2.label.isHidden = false
+            stopoverPointSelectView.stopover2.button.isHidden = false
+            stopoverCount += 1
+        } else {
+            stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
+                make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
+                make.bottom.equalTo(stopoverPointSelectView.nextButton.snp.top).offset(-30)
+                make.leading.equalTo(stopoverPointSelectView).inset(20)
+            }
+            stopoverPointSelectView.stopoverAddButton.isHidden = true
+            stopoverPointSelectView.stopover3.label.isHidden = false
+            stopoverPointSelectView.stopover3.button.isHidden = false
+            stopoverCount += 1
+        }
+    }
 
     @objc private func findAddressButtonTapped(_ sender: UIButton) {
         let detailViewController = SelectAddressViewController()
@@ -43,10 +68,10 @@ extension StopoverPointSelectViewController {
             }
         }()
 
-        detailViewController.addressSelectionHandler = { [weak self] addressDTO in
-            // TODO: 다음 작업에 Model에 값 적재하는 로직 구현 필요
-
-        }
+//        detailViewController.addressSelectionHandler = { [weak self] addressDTO in
+//            // TODO: 다음 작업에 Model에 값 적재하는 로직 구현 필요
+//
+//        }
         present(navigation, animated: true)
     }
 

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -15,8 +15,19 @@ final class StopoverPointSelectViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor.semantic.backgroundDefault
-
         // TODO: 출발지, 도착지 주소 텍스트 설정
+        addButtonTarget()
+        view.addSubview(stopoverPointSelectView)
+        stopoverPointSelectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - custom Method
+extension StopoverPointSelectViewController {
+
+    private func addButtonTarget() {
         stopoverPointSelectView.nextButton.addTarget(
             self,
             action: #selector(nextButtonTapped),
@@ -37,10 +48,6 @@ final class StopoverPointSelectViewController: UIViewController {
             action: #selector(deletePointButtonTapped),
             for: .touchUpInside
         )
-        view.addSubview(stopoverPointSelectView)
-        stopoverPointSelectView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
     }
 }
 

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -1,0 +1,69 @@
+//
+//  StopoverSelectViewController.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/8/23.
+//
+
+import UIKit
+
+final class StopoverPointSelectViewController: UIViewController {
+
+    private let stopoverPointSelectView = StopoverPointSelectView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.semantic.backgroundDefault
+
+        // TODO: 출발지, 도착지 주소 텍스트 설정
+        stopoverPointSelectView.nextButton.addTarget(
+            self,
+            action: #selector(nextButtonTapped),
+            for: .touchUpInside
+        )
+        view.addSubview(stopoverPointSelectView)
+        stopoverPointSelectView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - @objc Method
+extension StopoverPointSelectViewController {
+
+    @objc private func findAddressButtonTapped(_ sender: UIButton) {
+        let detailViewController = SelectAddressViewController()
+        let navigation = UINavigationController(rootViewController: detailViewController)
+
+        detailViewController.selectAddressView.headerTitleLabel.text = {
+            if sender.titleLabel?.text == "     출발지 검색" {
+                return "출발지 주소 설정"
+            } else {
+                return "도착지 주소 설정"
+            }
+        }()
+
+        detailViewController.addressSelectionHandler = { [weak self] addressDTO in
+            // TODO: 다음 작업에 Model에 값 적재하는 로직 구현 필요
+
+        }
+        present(navigation, animated: true)
+    }
+
+    @objc private func nextButtonTapped() {
+        // TODO: 다음화면 이동 구현 필요
+        let viewController = StopoverPointCheckViewController()
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+// MARK: - 프리뷰 canvas 세팅
+import SwiftUI
+
+struct SOPViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = StopoverPointSelectViewController
+    func makeUIViewController(context: Context) -> StopoverPointSelectViewController {
+        return StopoverPointSelectViewController()
+    }
+    func updateUIViewController(_ uiViewController: StopoverPointSelectViewController, context: Context) {}
+}

--- a/Carmu/Sources/SceneDelegate.swift
+++ b/Carmu/Sources/SceneDelegate.swift
@@ -44,7 +44,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         if Auth.auth().currentUser != nil {
             if SceneDelegate.isFirst {
-                rootViewController = PositionSelectViewController()
+                rootViewController = StopoverPointCheckViewController()
             } else {
                 rootViewController = SessionStartViewController()
             }

--- a/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
@@ -48,12 +48,9 @@ final class AddressSelectButtonView: UIView {
 
         pointLabel.snp.makeConstraints { make in
             make.top.horizontalEdges.equalToSuperview()
-            make.leading.equalToSuperview().inset(20)
-
         }
 
         selectPointButton.snp.makeConstraints { make in
-            make.top.equalTo(pointLabel.snp.bottom).offset(12)
             make.bottom.horizontalEdges.equalToSuperview()
         }
     }

--- a/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 /**
  경유지 설정 화면에서 선택하는 버튼.
  */
@@ -26,7 +27,7 @@ final class AddressSelectButtonView: UIView, SelectAddressButtonProtocol {
         return button
     }()
 
-    var button: UIButton = {
+    internal var button: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = UIFont.carmuFont.body2Long
         button.setTitleColor(UIColor.semantic.textBody, for: .normal)

--- a/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
@@ -1,0 +1,74 @@
+//
+//  AddressSelectButton.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/8/23.
+//
+
+import Foundation
+/**
+ 경유지 설정 화면에서 선택하는 버튼.
+ */
+final class AddressSelectButtonView: UIView {
+
+    private lazy var pointLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.carmuFont.headline1
+        label.textColor = UIColor.semantic.textPrimary
+
+        return label
+    }()
+
+    lazy var selectPointButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.titleLabel?.font = UIFont.carmuFont.body2Long
+        button.setTitleColor(UIColor.semantic.textBody, for: .normal)
+        button.layer.borderColor = UIColor.theme.blue3?.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = 15
+        button.contentHorizontalAlignment = .left
+        button.isSpringLoaded = true
+
+        return button
+    }()
+
+    /**
+     address: 출발지의 대표명
+     isStart: 도착지라면 false(기본값 true)
+     time: 출발 또는 도착 시간
+     */
+    init(textFieldTitle: String) {
+        super.init(frame: .zero)
+
+        pointLabel.text = textFieldTitle
+        selectPointButton.setTitle("     \(textFieldTitle) 검색", for: .normal)
+
+        addSubview(pointLabel)
+        addSubview(selectPointButton)
+
+        pointLabel.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+            make.leading.equalToSuperview().inset(20)
+
+        }
+
+        selectPointButton.snp.makeConstraints { make in
+            make.top.equalTo(pointLabel.snp.bottom).offset(12)
+            make.bottom.horizontalEdges.equalToSuperview()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// Preview
+import SwiftUI
+
+@available(iOS 13.0.0, *)
+struct ASBViewPreview: PreviewProvider {
+    static var previews: some View {
+        SEPViewControllerRepresentable()
+    }
+}

--- a/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
@@ -18,6 +18,14 @@ final class AddressSelectButtonView: UIView, SelectAddressButtonProtocol {
         return label
     }()
 
+    lazy var xButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = UIColor.theme.blue3
+        button.isHidden = true
+        return button
+    }()
+
     var button: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = UIFont.carmuFont.body2Long
@@ -35,7 +43,7 @@ final class AddressSelectButtonView: UIView, SelectAddressButtonProtocol {
      isStart: 도착지라면 false(기본값 true)
      time: 출발 또는 도착 시간
      */
-    init(textFieldTitle: String) {
+    init(textFieldTitle: String, hasXButton: Bool = false) {
         super.init(frame: .zero)
 
         label.text = textFieldTitle
@@ -43,6 +51,14 @@ final class AddressSelectButtonView: UIView, SelectAddressButtonProtocol {
 
         addSubview(label)
         addSubview(button)
+        if hasXButton {
+            addSubview(xButton)
+            xButton.snp.makeConstraints { make in
+                make.centerY.equalTo(label)
+                make.trailing.equalToSuperview()
+                make.width.height.equalTo(20)
+            }
+        }
 
         label.snp.makeConstraints { make in
             make.top.horizontalEdges.equalToSuperview()

--- a/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
@@ -9,17 +9,16 @@ import Foundation
 /**
  경유지 설정 화면에서 선택하는 버튼.
  */
-final class AddressSelectButtonView: UIView {
+final class AddressSelectButtonView: UIView, SelectAddressButtonProtocol {
 
-    private lazy var pointLabel: UILabel = {
+    internal var label: UILabel = {
         let label = UILabel()
         label.font = UIFont.carmuFont.headline1
         label.textColor = UIColor.semantic.textPrimary
-
         return label
     }()
 
-    lazy var selectPointButton: UIButton = {
+    var button: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = UIFont.carmuFont.body2Long
         button.setTitleColor(UIColor.semantic.textBody, for: .normal)
@@ -28,7 +27,6 @@ final class AddressSelectButtonView: UIView {
         button.layer.cornerRadius = 15
         button.contentHorizontalAlignment = .left
         button.isSpringLoaded = true
-
         return button
     }()
 
@@ -38,19 +36,19 @@ final class AddressSelectButtonView: UIView {
      time: 출발 또는 도착 시간
      */
     init(textFieldTitle: String) {
-        super.init(frame: .zero)
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 64))
 
-        pointLabel.text = textFieldTitle
-        selectPointButton.setTitle("     \(textFieldTitle) 검색", for: .normal)
+        label.text = textFieldTitle
+        button.setTitle("     \(textFieldTitle) 검색", for: .normal)
 
-        addSubview(pointLabel)
-        addSubview(selectPointButton)
+        addSubview(label)
+        addSubview(button)
 
-        pointLabel.snp.makeConstraints { make in
+        label.snp.makeConstraints { make in
             make.top.horizontalEdges.equalToSuperview()
         }
 
-        selectPointButton.snp.makeConstraints { make in
+        button.snp.makeConstraints { make in
             make.bottom.horizontalEdges.equalToSuperview()
         }
     }

--- a/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/AddressSelectButtonView.swift
@@ -36,7 +36,7 @@ final class AddressSelectButtonView: UIView, SelectAddressButtonProtocol {
      time: 출발 또는 도착 시간
      */
     init(textFieldTitle: String) {
-        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 64))
+        super.init(frame: .zero)
 
         label.text = textFieldTitle
         button.setTitle("     \(textFieldTitle) 검색", for: .normal)

--- a/Carmu/Sources/Utils/ButtonComponent/SelectAddressButtonProtocol.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/SelectAddressButtonProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  SelectAddressButtonProtocol.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/9/23.
+//
+
+import UIKit
+
+protocol SelectAddressButtonProtocol: UIView {
+    var button: UIButton { get set }
+    var label: UILabel { get set }
+}

--- a/Carmu/Sources/Utils/ButtonComponent/StopoverPointAddButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/StopoverPointAddButtonView.swift
@@ -10,6 +10,7 @@ import UIKit
 import SnapKit
 
 final class StopoverPointAddButtonView: UIView, SelectAddressButtonProtocol {
+
     var button: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("􀅼 경유지 추가", for: .normal)

--- a/Carmu/Sources/Utils/ButtonComponent/StopoverPointAddButtonView.swift
+++ b/Carmu/Sources/Utils/ButtonComponent/StopoverPointAddButtonView.swift
@@ -9,11 +9,6 @@ import UIKit
 
 import SnapKit
 
-protocol SelectAddressButtonProtocol: UIView {
-    var button: UIButton { get set }
-    var label: UILabel { get set }
-}
-
 final class StopoverPointAddButtonView: UIView, SelectAddressButtonProtocol {
     var button: UIButton = {
         let button = UIButton(type: .system)

--- a/Carmu/Sources/Views/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectView.swift
@@ -18,55 +18,8 @@ final class StartEndPointSelectView: UIView {
 
     private lazy var colorLine = CrewMakeUtil.createColorLineView()
 
-    private lazy var startPointStack = UIStackView()
-
-    private lazy var startLabel: UILabel = {
-        let label = UILabel()
-        label.text = "출발지"
-        label.font = UIFont.carmuFont.headline1
-        label.textColor = UIColor.semantic.textPrimary
-
-        return label
-    }()
-
-    lazy var startPointButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("     출발지 검색", for: .normal)
-        button.titleLabel?.font = UIFont.carmuFont.body2Long
-        button.setTitleColor(UIColor.semantic.textBody, for: .normal)
-        button.layer.borderColor = UIColor.theme.blue3?.cgColor
-        button.layer.borderWidth = 1
-        button.layer.cornerRadius = 15
-        button.contentHorizontalAlignment = .left
-        button.isSpringLoaded = true
-
-        return button
-    }()
-
-    private lazy var endPointStack = UIStackView()
-
-    private lazy var endLabel: UILabel = {
-        let label = UILabel()
-        label.text = "도착지"
-        label.font = UIFont.carmuFont.headline1
-        label.textColor = UIColor.semantic.textPrimary
-
-        return label
-    }()
-
-    lazy var endPointButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("     도착지 검색", for: .normal)
-        button.titleLabel?.font = UIFont.carmuFont.body2Long
-        button.setTitleColor(UIColor.semantic.textBody, for: .normal)
-        button.layer.borderColor = UIColor.theme.blue3?.cgColor
-        button.layer.borderWidth = 1
-        button.layer.cornerRadius = 15
-        button.contentHorizontalAlignment = .left
-        button.isSpringLoaded = true
-
-        return button
-    }()
+    let startPointView = AddressSelectButtonView(textFieldTitle: "출발지")
+    let endPointView = AddressSelectButtonView(textFieldTitle: "도착지")
 
     lazy var nextButton: UIButton = {
         let button = UIButton()
@@ -99,22 +52,16 @@ final class StartEndPointSelectView: UIView {
 
     private func setupViews() {
         firstLineTitleStack.axis = .horizontal
-        startPointStack.axis = .vertical
-        endPointStack.axis = .vertical
 
         firstLineTitleStack.addArrangedSubview(titleLabel1)
         firstLineTitleStack.addArrangedSubview(titleLabel2)
         firstLineTitleStack.addArrangedSubview(titleLabel3)
-        startPointStack.addArrangedSubview(startLabel)
-        startPointStack.addArrangedSubview(startPointButton)
-        endPointStack.addArrangedSubview(endLabel)
-        endPointStack.addArrangedSubview(endPointButton)
 
         addSubview(firstLineTitleStack)
         addSubview(titleLabel5)
         addSubview(colorLine)
-        addSubview(startPointStack)
-        addSubview(endPointStack)
+        addSubview(startPointView)
+        addSubview(endPointView)
         addSubview(nextButton)
     }
 
@@ -135,18 +82,18 @@ final class StartEndPointSelectView: UIView {
             make.height.equalTo(200)
         }
 
-        startPointStack.snp.makeConstraints { make in
+        startPointView.snp.makeConstraints { make in
             make.top.equalTo(colorLine).offset(8)
             make.leading.equalTo(colorLine.snp.trailing).offset(12)
             make.trailing.equalToSuperview().inset(32)
-            make.height.equalTo(74)
+            make.height.equalTo(64)
         }
 
-        endPointStack.snp.makeConstraints { make in
+        endPointView.snp.makeConstraints { make in
             make.bottom.equalTo(colorLine).offset(-8)
             make.leading.equalTo(colorLine.snp.trailing).offset(12)
             make.trailing.equalToSuperview().inset(32)
-            make.height.equalTo(startPointStack)
+            make.height.equalTo(startPointView)
         }
 
         nextButton.snp.makeConstraints { make in

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointAddButtonView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointAddButtonView.swift
@@ -9,9 +9,13 @@ import UIKit
 
 import SnapKit
 
-final class StopoverPointAddButtonView: UIView {
+protocol SelectAddressButtonProtocol: UIView {
+    var button: UIButton { get set }
+    var label: UILabel { get set }
+}
 
-    let addPointButton: UIButton = {
+final class StopoverPointAddButtonView: UIView, SelectAddressButtonProtocol {
+    var button: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("􀅼 경유지 추가", for: .normal)
         button.titleLabel?.font = UIFont.carmuFont.subhead2
@@ -22,7 +26,7 @@ final class StopoverPointAddButtonView: UIView {
         return button
     }()
 
-    private let buttonLabel: UILabel = {
+    var label: UILabel = {
         let label = UILabel()
         label.text = "경유지는 최대 3개까지 생성할 수 있습니다."
         label.font = UIFont.carmuFont.body1Long
@@ -30,28 +34,24 @@ final class StopoverPointAddButtonView: UIView {
         return label
     }()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
+    init() {
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 50))
+        addSubview(button)
+        addSubview(label)
 
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-
-    override func draw(_ rect: CGRect) {
-
-        addSubview(addPointButton)
-        addSubview(buttonLabel)
-
-        addPointButton.snp.makeConstraints { make in
+        button.snp.makeConstraints { make in
             make.top.leading.equalToSuperview()
             make.width.equalTo(108)
             make.height.equalTo(30)
         }
 
-        buttonLabel.snp.makeConstraints { make in
-            make.top.equalTo(addPointButton.snp.bottom).offset(12)
+        label.snp.makeConstraints { make in
+            make.top.equalTo(button.snp.bottom).offset(6)
             make.bottom.horizontalEdges.equalToSuperview()
         }
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
     }
 }

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointAddButtonView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointAddButtonView.swift
@@ -1,0 +1,57 @@
+//
+//  StopoverPointAddButtonView.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/9/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class StopoverPointAddButtonView: UIView {
+
+    let addPointButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("􀅼 경유지 추가", for: .normal)
+        button.titleLabel?.font = UIFont.carmuFont.subhead2
+        button.setTitleColor(UIColor.semantic.textSecondary, for: .normal)
+        button.setBackgroundImage(UIImage(color: UIColor.semantic.accPrimary ?? .white), for: .normal)
+        button.layer.cornerRadius = 15
+        button.layer.masksToBounds = true
+        return button
+    }()
+
+    private let buttonLabel: UILabel = {
+        let label = UILabel()
+        label.text = "경유지는 최대 3개까지 생성할 수 있습니다."
+        label.font = UIFont.carmuFont.body1Long
+        label.textColor = UIColor.semantic.textBody
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func draw(_ rect: CGRect) {
+
+        addSubview(addPointButton)
+        addSubview(buttonLabel)
+
+        addPointButton.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+            make.width.equalTo(108)
+            make.height.equalTo(30)
+        }
+
+        buttonLabel.snp.makeConstraints { make in
+            make.top.equalTo(addPointButton.snp.bottom).offset(12)
+            make.bottom.horizontalEdges.equalToSuperview()
+        }
+    }
+}

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
@@ -129,14 +129,17 @@ final class StopoverPointSelectView: UIView {
 
         stopover1.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(64)
         }
 
         stopover2.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
+            make.height.equalTo(64)
         }
 
         stopover3.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
+            make.height.equalTo(64)
         }
 
         endPointView.snp.makeConstraints { make in

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
@@ -11,15 +11,13 @@ import SnapKit
 
 final class StopoverPointSelectView: UIView {
 
-    private lazy var firstLineTitleStack = UIStackView()
-
-    private lazy var titleLabel1 = CrewMakeUtil.defalutTitle(titleText: "크루원들의 ")
-    private lazy var titleLabel2 = CrewMakeUtil.accPrimaryTitle(titleText: "경유지")
-    private lazy var titleLabel3 = CrewMakeUtil.defalutTitle(titleText: "를")
+    private let firstLineTitleStack = UIStackView()
+    private let titleLabel1 = CrewMakeUtil.defalutTitle(titleText: "크루원들의 ")
+    private let titleLabel2 = CrewMakeUtil.accPrimaryTitle(titleText: "경유지")
+    private let titleLabel3 = CrewMakeUtil.defalutTitle(titleText: "를")
     let titleLabel5 = CrewMakeUtil.defalutTitle(titleText: "설정해주세요")
 
     let colorLine = CrewMakeUtil.createColorLineView()
-
     let startPointView: UILabel = {
         let label = UILabel()
         label.text = "출발지 주소"
@@ -27,14 +25,17 @@ final class StopoverPointSelectView: UIView {
         label.textColor = UIColor.semantic.textTertiary
         return label
     }()
-
     let stopoverStackView = UIStackView()
     let stopover1 = AddressSelectButtonView(textFieldTitle: "경유지 1")
-    var stopover2 = AddressSelectButtonView(textFieldTitle: "경유지 2", hasXButton: true)
-    var stopover3 = AddressSelectButtonView(textFieldTitle: "경유지 3", hasXButton: true)
-
+    lazy var stopover2 = AddressSelectButtonView(
+        textFieldTitle: "경유지 2",
+        hasXButton: true
+    )
+    lazy var stopover3 = AddressSelectButtonView(
+        textFieldTitle: "경유지 3",
+        hasXButton: true
+    )
     let stopoverAddButton = StopoverPointAddButtonView()
-
     let endPointView: UILabel = {
         let label = UILabel()
         label.text = "도착지 주소"
@@ -54,11 +55,15 @@ final class StopoverPointSelectView: UIView {
     }
 
     override func draw(_ rect: CGRect) {
-        setupViews()
+        setupUI()
         setupConstraints()
     }
+}
 
-    private func setupViews() {
+// MARK: - setup UI
+extension StopoverPointSelectView {
+
+    private func setupUI() {
         firstLineTitleStack.axis = .horizontal
         stopoverStackView.axis = .vertical
         stopoverStackView.distribution = .equalSpacing

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
@@ -30,8 +30,8 @@ final class StopoverPointSelectView: UIView {
 
     let stopoverStackView = UIStackView()
     let stopover1 = AddressSelectButtonView(textFieldTitle: "경유지 1")
-    var stopover2 = AddressSelectButtonView(textFieldTitle: "경유지 2")
-    var stopover3 = AddressSelectButtonView(textFieldTitle: "경유지 3")
+    var stopover2 = AddressSelectButtonView(textFieldTitle: "경유지 2", hasXButton: true)
+    var stopover3 = AddressSelectButtonView(textFieldTitle: "경유지 3", hasXButton: true)
 
     let stopoverAddButton = StopoverPointAddButtonView()
 

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
@@ -28,6 +28,11 @@ final class StopoverPointSelectView: UIView {
         return label
     }()
 
+    let stopoverStackView = UIStackView()
+    let stopover1 = AddressSelectButtonView(textFieldTitle: "경유지 1")
+    var stopover2: UIView = StopoverPointAddButtonView()
+    var stopover3: UIView?
+
     let endPointView: UILabel = {
         let label = UILabel()
         label.text = "도착지 주소"
@@ -48,25 +53,39 @@ final class StopoverPointSelectView: UIView {
 
     override func draw(_ rect: CGRect) {
         setupViews()
-        setAutoLayout()
+        setupConstraints()
     }
 
     private func setupViews() {
         firstLineTitleStack.axis = .horizontal
+        stopoverStackView.axis = .vertical
+        stopoverStackView.distribution = .equalSpacing
 
         firstLineTitleStack.addArrangedSubview(titleLabel1)
         firstLineTitleStack.addArrangedSubview(titleLabel2)
         firstLineTitleStack.addArrangedSubview(titleLabel3)
+        stopoverStackView.addArrangedSubview(stopover1)
+        stopoverStackView.addArrangedSubview(stopover2)
+
+        if let stopover3 = stopover3 {
+            stopoverStackView.addArrangedSubview(stopover3)
+        }
 
         addSubview(firstLineTitleStack)
         addSubview(titleLabel5)
         addSubview(colorLine)
         addSubview(startPointView)
+        addSubview(stopoverStackView)
         addSubview(endPointView)
         addSubview(nextButton)
     }
 
-    private func setAutoLayout() {
+    private func setupConstraints() {
+        setAutoLayout1()
+        setAutoLayout2()
+    }
+
+    private func setAutoLayout1() {
         firstLineTitleStack.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).inset(36)
             make.leading.equalToSuperview().inset(20)
@@ -78,19 +97,48 @@ final class StopoverPointSelectView: UIView {
         }
 
         colorLine.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel5.snp.bottom).offset(40)
+            make.top.equalTo(titleLabel5.snp.bottom).offset(30)
             make.leading.equalToSuperview().inset(20)
-            make.bottom.equalTo(nextButton.snp.top).offset(-56)
+            make.height.equalTo(314)
         }
 
         startPointView.snp.makeConstraints { make in
-            make.top.equalTo(colorLine).offset(12)
+            make.top.equalTo(colorLine).offset(2)
+            make.leading.equalTo(colorLine.snp.trailing).offset(12)
+            make.trailing.equalToSuperview().inset(32)
+        }
+    }
+
+    private func setAutoLayout2() {
+        stopoverStackView.snp.makeConstraints { make in
+            make.top.equalTo(startPointView.snp.bottom).offset(20)
+            make.bottom.equalTo(endPointView.snp.top).offset(-40)
             make.leading.equalTo(colorLine.snp.trailing).offset(12)
             make.trailing.equalToSuperview().inset(32)
         }
 
+        stopover1.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(15)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(64)
+        }
+
+        stopover2.snp.makeConstraints { make in
+            make.top.equalTo(stopover1.snp.bottom).offset(20)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(60)
+        }
+
+        if let stopover3 = stopover3 {
+            stopover3.snp.makeConstraints { make in
+                make.top.equalTo(stopover2.snp.bottom).offset(20)
+                make.leading.trailing.equalToSuperview()
+                make.height.equalTo(60)
+            }
+        }
+
         endPointView.snp.makeConstraints { make in
-            make.bottom.equalTo(colorLine).offset(-12)
+            make.bottom.equalTo(colorLine).offset(-2)
             make.leading.equalTo(colorLine.snp.trailing).offset(12)
             make.trailing.equalToSuperview().inset(32)
         }

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
@@ -16,9 +16,9 @@ final class StopoverPointSelectView: UIView {
     private lazy var titleLabel1 = CrewMakeUtil.defalutTitle(titleText: "크루원들의 ")
     private lazy var titleLabel2 = CrewMakeUtil.accPrimaryTitle(titleText: "경유지")
     private lazy var titleLabel3 = CrewMakeUtil.defalutTitle(titleText: "를")
-    private lazy var titleLabel5 = CrewMakeUtil.defalutTitle(titleText: "설정해주세요")
+    let titleLabel5 = CrewMakeUtil.defalutTitle(titleText: "설정해주세요")
 
-    private lazy var colorLine = CrewMakeUtil.createColorLineView()
+    let colorLine = CrewMakeUtil.createColorLineView()
 
     let startPointView: UILabel = {
         let label = UILabel()
@@ -30,8 +30,10 @@ final class StopoverPointSelectView: UIView {
 
     let stopoverStackView = UIStackView()
     let stopover1 = AddressSelectButtonView(textFieldTitle: "경유지 1")
-    var stopover2: UIView = StopoverPointAddButtonView()
-    var stopover3: UIView?
+    var stopover2 = AddressSelectButtonView(textFieldTitle: "경유지 2")
+    var stopover3 = AddressSelectButtonView(textFieldTitle: "경유지 3")
+
+    let stopoverAddButton = StopoverPointAddButtonView()
 
     let endPointView: UILabel = {
         let label = UILabel()
@@ -66,26 +68,29 @@ final class StopoverPointSelectView: UIView {
         firstLineTitleStack.addArrangedSubview(titleLabel3)
         stopoverStackView.addArrangedSubview(stopover1)
         stopoverStackView.addArrangedSubview(stopover2)
+        stopoverStackView.addArrangedSubview(stopover3)
 
-        if let stopover3 = stopover3 {
-            stopoverStackView.addArrangedSubview(stopover3)
-        }
+        stopover2.label.isHidden = true
+        stopover2.button.isHidden = true
+        stopover3.label.isHidden = true
+        stopover3.button.isHidden = true
 
         addSubview(firstLineTitleStack)
         addSubview(titleLabel5)
         addSubview(colorLine)
         addSubview(startPointView)
         addSubview(stopoverStackView)
+        addSubview(stopoverAddButton)
         addSubview(endPointView)
         addSubview(nextButton)
     }
 
     private func setupConstraints() {
-        setAutoLayout1()
-        setAutoLayout2()
+        setAutoLayoutTop()
+        setAutoLayoutBottom()
     }
 
-    private func setAutoLayout1() {
+    private func setAutoLayoutTop() {
         firstLineTitleStack.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).inset(36)
             make.leading.equalToSuperview().inset(20)
@@ -98,8 +103,8 @@ final class StopoverPointSelectView: UIView {
 
         colorLine.snp.makeConstraints { make in
             make.top.equalTo(titleLabel5.snp.bottom).offset(30)
+            make.bottom.equalTo(stopover2).offset(30)
             make.leading.equalToSuperview().inset(20)
-            make.height.equalTo(314)
         }
 
         startPointView.snp.makeConstraints { make in
@@ -109,32 +114,29 @@ final class StopoverPointSelectView: UIView {
         }
     }
 
-    private func setAutoLayout2() {
+    private func setAutoLayoutBottom() {
         stopoverStackView.snp.makeConstraints { make in
-            make.top.equalTo(startPointView.snp.bottom).offset(20)
-            make.bottom.equalTo(endPointView.snp.top).offset(-40)
+            make.top.equalTo(startPointView.snp.bottom).offset(30)
+            make.bottom.equalTo(nextButton.snp.top).offset(-90)
             make.leading.equalTo(colorLine.snp.trailing).offset(12)
             make.trailing.equalToSuperview().inset(32)
         }
 
+        stopoverAddButton.snp.makeConstraints { make in
+            make.bottom.equalTo(endPointView.snp.top).offset(-12)
+            make.leading.trailing.equalTo(stopoverStackView)
+        }
+
         stopover1.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(15)
             make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(64)
         }
 
         stopover2.snp.makeConstraints { make in
-            make.top.equalTo(stopover1.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(60)
         }
 
-        if let stopover3 = stopover3 {
-            stopover3.snp.makeConstraints { make in
-                make.top.equalTo(stopover2.snp.bottom).offset(20)
-                make.leading.trailing.equalToSuperview()
-                make.height.equalTo(60)
-            }
+        stopover3.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
         }
 
         endPointView.snp.makeConstraints { make in

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectView.swift
@@ -1,0 +1,114 @@
+//
+//  StopoverPointSelect.swift
+//  Carmu
+//
+//  Created by 김동현 on 11/8/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class StopoverPointSelectView: UIView {
+
+    private lazy var firstLineTitleStack = UIStackView()
+
+    private lazy var titleLabel1 = CrewMakeUtil.defalutTitle(titleText: "크루원들의 ")
+    private lazy var titleLabel2 = CrewMakeUtil.accPrimaryTitle(titleText: "경유지")
+    private lazy var titleLabel3 = CrewMakeUtil.defalutTitle(titleText: "를")
+    private lazy var titleLabel5 = CrewMakeUtil.defalutTitle(titleText: "설정해주세요")
+
+    private lazy var colorLine = CrewMakeUtil.createColorLineView()
+
+    let startPointView: UILabel = {
+        let label = UILabel()
+        label.text = "출발지 주소"
+        label.font = UIFont.carmuFont.headline1
+        label.textColor = UIColor.semantic.textTertiary
+        return label
+    }()
+
+    let endPointView: UILabel = {
+        let label = UILabel()
+        label.text = "도착지 주소"
+        label.font = UIFont.carmuFont.headline1
+        label.textColor = UIColor.semantic.textTertiary
+        return label
+    }()
+
+    let nextButton = NextButton(buttonTitle: "다음")
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func draw(_ rect: CGRect) {
+        setupViews()
+        setAutoLayout()
+    }
+
+    private func setupViews() {
+        firstLineTitleStack.axis = .horizontal
+
+        firstLineTitleStack.addArrangedSubview(titleLabel1)
+        firstLineTitleStack.addArrangedSubview(titleLabel2)
+        firstLineTitleStack.addArrangedSubview(titleLabel3)
+
+        addSubview(firstLineTitleStack)
+        addSubview(titleLabel5)
+        addSubview(colorLine)
+        addSubview(startPointView)
+        addSubview(endPointView)
+        addSubview(nextButton)
+    }
+
+    private func setAutoLayout() {
+        firstLineTitleStack.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).inset(36)
+            make.leading.equalToSuperview().inset(20)
+        }
+
+        titleLabel5.snp.makeConstraints { make in
+            make.top.equalTo(firstLineTitleStack.snp.bottom)
+            make.leading.equalToSuperview().inset(20)
+        }
+
+        colorLine.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel5.snp.bottom).offset(40)
+            make.leading.equalToSuperview().inset(20)
+            make.bottom.equalTo(nextButton.snp.top).offset(-56)
+        }
+
+        startPointView.snp.makeConstraints { make in
+            make.top.equalTo(colorLine).offset(12)
+            make.leading.equalTo(colorLine.snp.trailing).offset(12)
+            make.trailing.equalToSuperview().inset(32)
+        }
+
+        endPointView.snp.makeConstraints { make in
+            make.bottom.equalTo(colorLine).offset(-12)
+            make.leading.equalTo(colorLine.snp.trailing).offset(12)
+            make.trailing.equalToSuperview().inset(32)
+        }
+
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(60)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(60)
+        }
+    }
+}
+
+// Preview
+import SwiftUI
+
+@available(iOS 13.0.0, *)
+struct StopoverPointSelectViewPreview: PreviewProvider {
+    static var previews: some View {
+        SOPViewControllerRepresentable()
+    }
+}


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Feat: 새로운 기능을 추가
- [x] Fix: 버그 수정
- [x] Design: CSS 등 사용자 UI 디자인 변경

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

경유지 설정 화면 작업을 마쳤습니다. 하지만, 상세 위치 설정은 단위가 커질 것 같아 또 분리하였습니다.

경유지 화면 구현을 조금 특이하게 진행하였는데, 경유지 버튼들을 모두 숨겨놓고, 컬러라인과 도착지 라벨의 constraints를 remake하여 추가할 때마다 움직이는 것 처럼 구현하였습니다. 아래 gif를 참고하시면 되겠습니다.

추후 어색해보이는 큰 화면에서의 레이아웃은 수정을 진행할 예정입니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: N/A

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #152 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
![Simulator Screen Recording - iPhone 8 - 2023-11-09 at 17 48 46](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/2b83be32-c55f-43d0-8cea-cdf1c58c8905)
<iPhone 8>


![Simulator Screen Recording - iPhone 15 Pro Max - 2023-11-09 at 17 49 51](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/0675a701-9cb9-440c-a469-a63411c0fa76)
<iPhone 15 pro max>


