### PR TITLE
[Feat] crewStatus 변경 및 collectionView에 적용

### DIFF
--- a/Carmu.xcodeproj/project.pbxproj
+++ b/Carmu.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		163422342AFDFFFE00196EB2 /* CarpoolPlanLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163422332AFDFFFE00196EB2 /* CarpoolPlanLabel.swift */; };
 		163422362AFE636000196EB2 /* RuleDescriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163422352AFE636000196EB2 /* RuleDescriptionViewController.swift */; };
 		163422382AFE67A400196EB2 /* RuleDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163422372AFE67A400196EB2 /* RuleDescriptionView.swift */; };
-		1638B91F2B02FBB300C53D0D /* CrewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1638B91E2B02FBB300C53D0D /* CrewStatus.swift */; };
+		1638B91F2B02FBB300C53D0D /* MemeberStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1638B91E2B02FBB300C53D0D /* MemeberStatus.swift */; };
 		163FA65A2AE15F04005F2A77 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 163FA6592AE15F04005F2A77 /* FirebaseFunctions */; };
 		164E823D2AF53AB400848BFF /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164E823C2AF53AB400848BFF /* Point.swift */; };
 		165055AD2AFF54C50049EF73 /* StopoverInfoLeftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165055AC2AFF54C50049EF73 /* StopoverInfoLeftView.swift */; };
@@ -137,7 +137,7 @@
 		163422332AFDFFFE00196EB2 /* CarpoolPlanLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarpoolPlanLabel.swift; sourceTree = "<group>"; };
 		163422352AFE636000196EB2 /* RuleDescriptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleDescriptionViewController.swift; sourceTree = "<group>"; };
 		163422372AFE67A400196EB2 /* RuleDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleDescriptionView.swift; sourceTree = "<group>"; };
-		1638B91E2B02FBB300C53D0D /* CrewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrewStatus.swift; sourceTree = "<group>"; };
+		1638B91E2B02FBB300C53D0D /* MemeberStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemeberStatus.swift; sourceTree = "<group>"; };
 		164E823C2AF53AB400848BFF /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		165055AC2AFF54C50049EF73 /* StopoverInfoLeftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverInfoLeftView.swift; sourceTree = "<group>"; };
 		165055AE2AFF603D0049EF73 /* StopoverInfoRightView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopoverInfoRightView.swift; sourceTree = "<group>"; };
@@ -539,7 +539,7 @@
 				C904D1572AD57942008BF5CE /* Friendship.swift */,
 				C904D1602AD57AE8008BF5CE /* Crew.swift */,
 				164E823C2AF53AB400848BFF /* Point.swift */,
-				1638B91E2B02FBB300C53D0D /* CrewStatus.swift */,
+				1638B91E2B02FBB300C53D0D /* MemeberStatus.swift */,
 				C93116792AF3B69F0014E702 /* SelectAddressDTO.swift */,
 				C931167B2AF3B7070014E702 /* AddressDTO.swift */,
 			);
@@ -938,7 +938,7 @@
 				C95462192AF75A42004C4F6D /* TimeSelectModalViewController.swift in Sources */,
 				B8376E4A2AF9BC51007F1E0A /* NameEditView.swift in Sources */,
 				BF4A12472ABED8E900EC1B6D /* UIColor+Extension.swift in Sources */,
-				1638B91F2B02FBB300C53D0D /* CrewStatus.swift in Sources */,
+				1638B91F2B02FBB300C53D0D /* MemeberStatus.swift in Sources */,
 				B84B41852B000EFC007AC36F /* QuestionDetailViewController.swift in Sources */,
 				C904D1582AD57942008BF5CE /* Friendship.swift in Sources */,
 				B8376E482AF9BBB1007F1E0A /* NameEditViewController.swift in Sources */,

--- a/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
@@ -136,7 +136,7 @@ struct BPSViewControllerRepresentable: UIViewControllerRepresentable {
         return BoardingPointSelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [CrewStatus]()
+                memberStatus: [MemeberStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
@@ -136,7 +136,7 @@ struct BPSViewControllerRepresentable: UIViewControllerRepresentable {
         return BoardingPointSelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [UserIdentifier: Status]()
+                crewStatus: [CrewStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Crew/InviteCodeInputViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/InviteCodeInputViewController.swift
@@ -11,7 +11,7 @@ final class InviteCodeInputViewController: UIViewController {
 
     private let inviteCodeInputView = InviteCodeInputView()
     private let firebaseManager = FirebaseManager()
-    private var crewData = Crew(crews: [UserIdentifier](), crewStatus: [CrewStatus]())
+    private var crewData = Crew(crews: [UserIdentifier](), memberStatus: [MemeberStatus]())
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Carmu/Sources/Controllers/CrewMake/Crew/InviteCodeInputViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/InviteCodeInputViewController.swift
@@ -11,7 +11,7 @@ final class InviteCodeInputViewController: UIViewController {
 
     private let inviteCodeInputView = InviteCodeInputView()
     private let firebaseManager = FirebaseManager()
-    private var crewData = Crew(crews: [UserIdentifier](), crewStatus: [UserIdentifier: Status]())
+    private var crewData = Crew(crews: [UserIdentifier](), crewStatus: [CrewStatus]())
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Carmu/Sources/Controllers/CrewMake/Driver/FinalConfirmViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/FinalConfirmViewController.swift
@@ -171,7 +171,7 @@ struct FCViewControllerRepresentable: UIViewControllerRepresentable {
         return FinalConfirmViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [CrewStatus]()
+                memberStatus: [MemeberStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/FinalConfirmViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/FinalConfirmViewController.swift
@@ -171,7 +171,7 @@ struct FCViewControllerRepresentable: UIViewControllerRepresentable {
         return FinalConfirmViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [UserIdentifier: Status]()
+                crewStatus: [CrewStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/RepeatDaySelect/RepeatDaySelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/RepeatDaySelect/RepeatDaySelectViewController.swift
@@ -220,7 +220,7 @@ struct RDSViewControllerRepresentable: UIViewControllerRepresentable {
         return RepeatDaySelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [CrewStatus]()
+                memberStatus: [MemeberStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/RepeatDaySelect/RepeatDaySelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/RepeatDaySelect/RepeatDaySelectViewController.swift
@@ -220,7 +220,7 @@ struct RDSViewControllerRepresentable: UIViewControllerRepresentable {
         return RepeatDaySelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [UserIdentifier: Status]()
+                crewStatus: [CrewStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class StartEndPointSelectViewController: UIViewController {
 
     private let startEndPointSelectView = StartEndPointSelectView()
-    var crewData = Crew(crews: [UserIdentifier](), crewStatus: [CrewStatus]())
+    var crewData = Crew(crews: [UserIdentifier](), memberStatus: [MemeberStatus]())
 
     private var startPointAddress: String? {
         didSet {

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StartEndPointSelect/StartEndPointSelectViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class StartEndPointSelectViewController: UIViewController {
 
     private let startEndPointSelectView = StartEndPointSelectView()
-    var crewData = Crew(crews: [UserIdentifier](), crewStatus: [UserIdentifier: Status]())
+    var crewData = Crew(crews: [UserIdentifier](), crewStatus: [CrewStatus]())
 
     private var startPointAddress: String? {
         didSet {

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
@@ -64,7 +64,7 @@ import SwiftUI
 struct SPCViewControllerRepresentable: UIViewControllerRepresentable {
     typealias UIViewControllerType = StopoverPointCheckViewController
     func makeUIViewController(context: Context) -> StopoverPointCheckViewController {
-        return StopoverPointCheckViewController(crewData: Crew(crews: [UserIdentifier](), crewStatus: [CrewStatus]()))
+        return StopoverPointCheckViewController(crewData: Crew(crews: [UserIdentifier](), memberStatus: [MemeberStatus]()))
     }
     func updateUIViewController(_ uiViewController: StopoverPointCheckViewController, context: Context) {}
 }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
@@ -64,7 +64,7 @@ import SwiftUI
 struct SPCViewControllerRepresentable: UIViewControllerRepresentable {
     typealias UIViewControllerType = StopoverPointCheckViewController
     func makeUIViewController(context: Context) -> StopoverPointCheckViewController {
-        return StopoverPointCheckViewController(crewData: Crew(crews: [UserIdentifier](), crewStatus: [:]))
+        return StopoverPointCheckViewController(crewData: Crew(crews: [UserIdentifier](), crewStatus: [CrewStatus]()))
     }
     func updateUIViewController(_ uiViewController: StopoverPointCheckViewController, context: Context) {}
 }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
@@ -271,7 +271,7 @@ struct SDSPControllerRepresentable: UIViewControllerRepresentable {
         return SelectDetailStopoverPointViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [CrewStatus]()
+                memberStatus: [MemeberStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
@@ -271,7 +271,7 @@ struct SDSPControllerRepresentable: UIViewControllerRepresentable {
         return SelectDetailStopoverPointViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [UserIdentifier: Status]()
+                crewStatus: [CrewStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -189,7 +189,7 @@ struct SOPViewControllerRepresentable: UIViewControllerRepresentable {
         return StopoverPointSelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [CrewStatus]()
+                memberStatus: [MemeberStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -189,7 +189,7 @@ struct SOPViewControllerRepresentable: UIViewControllerRepresentable {
         return StopoverPointSelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [UserIdentifier: Status]()
+                crewStatus: [CrewStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
@@ -184,7 +184,7 @@ struct TSViewControllerRepresentable: UIViewControllerRepresentable {
         return TimeSelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [CrewStatus]()
+                memberStatus: [MemeberStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
@@ -184,7 +184,7 @@ struct TSViewControllerRepresentable: UIViewControllerRepresentable {
         return TimeSelectViewController(
             crewData: Crew(
                 crews: [UserIdentifier](),
-                crewStatus: [UserIdentifier: Status]()
+                crewStatus: [CrewStatus]()
             )
         )
     }

--- a/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
+++ b/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
@@ -35,28 +35,20 @@ final class SessionStartViewController: UIViewController {
         Task {
             do {
                 showActivityIndicator()
-                if let crewData = try await firebaseManager.getCrewData() {
-                    setupUI()
-                    setupConstraints()
-                    setTargetButton()
-                    hideActivityIndicator()
-                    // 성공적으로 crew 데이터를 받아왔을 경우
-                    print("Received crew data: \(crewData)")
-                    isCaptain = try await firebaseManager.checkCaptain()
-
-                    checkCrew(crewData: crewData)
+                let crewData = try await firebaseManager.getCrewData()
+                hideActivityIndicator()
+                setupUI()
+                setupConstraints()
+                setTargetButton()
+                print("Received crew data: \(String(describing: crewData))")
+                isCaptain = try await firebaseManager.checkCaptain()
+                checkCrew(crewData: crewData)
+                if let crewData = crewData {
                     settingData(crewData: crewData)
-
                     // DriverView
                     sessionStartDriverView.driverFrontView.settingDriverFrontData(crewData: crewData)
-
                     sessionStartDriverView.driverFrontView.crewData = crewData
                     sessionStartDriverView.driverFrontView.crewCollectionView.reloadData()
-
-                } else {
-                    // crew 데이터를 받아오지 못했을 경우
-                    crewData = nil
-                    print("Failed to get crew data")
                 }
             } catch {
                 // 어떤 에러가 발생했을 경우

--- a/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
+++ b/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
@@ -490,7 +490,6 @@ extension SessionStartViewController {
 
     // 운전자일 때
     private func settingIndividualButtonForDriver() {
-        guard let crewData = dummyCrewData else { return }
 
         // 모든 경우에 같은 화면임
         sessionStartView.notifyComment.text = "오늘의 카풀 운행 여부를\n전달했어요"

--- a/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
+++ b/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
@@ -586,20 +586,20 @@ extension SessionStartViewController {
     // TODO: - 실제 데이터로 변경 및 데이터 값 변경될 때 Observer로 확인
     // 함께하는 크루원이 한 명 이상일 때 버튼 Enable
     private func checkingCrewStatus() {
-        guard let crewData = dummyCrewData else { return }
-
-        // crewStatus를 순회하면서 .accept 상태의 크루원 확인
-        let isAnyMemberAccepted = crewData.crewStatus.values.contains { status in
-            return status == .accept
-        }
-
-        if isAnyMemberAccepted {  // 수락한 크루원이 한 명이라도 있을 경우
-            sessionStartView.carpoolStartButton.isEnabled = true
-            sessionStartView.notifyComment.text = "현재 탑승 응답한 크루원들과\n여정을 시작할까요?"
-        } else {    // 수락한 크루원이 없을 때
-            sessionStartView.carpoolStartButton.isEnabled = false
-            sessionStartView.carpoolStartButton.backgroundColor = UIColor.semantic.backgroundThird
-        }
+//        guard let crewData = dummyCrewData else { return }
+//
+//        // crewStatus를 순회하면서 .accept 상태의 크루원 확인
+//        let isAnyMemberAccepted = crewData.crewStatus.values.contains { status in
+//            return status == .accept
+//        }
+//
+//        if isAnyMemberAccepted {  // 수락한 크루원이 한 명이라도 있을 경우
+//            sessionStartView.carpoolStartButton.isEnabled = true
+//            sessionStartView.notifyComment.text = "현재 탑승 응답한 크루원들과\n여정을 시작할까요?"
+//        } else {    // 수락한 크루원이 없을 때
+//            sessionStartView.carpoolStartButton.isEnabled = false
+//            sessionStartView.carpoolStartButton.backgroundColor = UIColor.semantic.backgroundThird
+//        }
     }
 }
 

--- a/Carmu/Sources/Models/DTO/Crew.swift
+++ b/Carmu/Sources/Models/DTO/Crew.swift
@@ -30,7 +30,7 @@ struct Crew: Codable {
     var inviteCode: String?
     var repeatDay: [Int]?
     var sessionStatus: Status?
-    var crewStatus: [CrewStatus]?
+    var memberStatus: [MemeberStatus]?
 //    var crewStatus: [UserIdentifier: Status]
 }
 
@@ -107,9 +107,9 @@ var dummyCrewData: Crew? = Crew(
     inviteCode: "0101010",
     repeatDay: [1, 2, 3, 4, 5],
     sessionStatus: .waiting,
-    crewStatus: [CrewStatus(nickname: "uni", profileColor: "blue", status: .waiting),
-                 CrewStatus(nickname: "rei", profileColor: "red", status: .waiting),
-                 CrewStatus(nickname: "bazzi", profileColor: "red", status: .waiting)]
+    memberStatus: [MemeberStatus(nickname: "uni", profileColor: "blue", status: .waiting),
+                 MemeberStatus(nickname: "rei", profileColor: "red", status: .waiting),
+                 MemeberStatus(nickname: "bazzi", profileColor: "red", status: .waiting)]
 //    crewStatus: ["uni": .waiting, "rei": .waiting]
 )
 

--- a/Carmu/Sources/Models/DTO/Crew.swift
+++ b/Carmu/Sources/Models/DTO/Crew.swift
@@ -30,8 +30,8 @@ struct Crew: Codable {
     var inviteCode: String?
     var repeatDay: [Int]?
     var sessionStatus: Status?
-//    var crewStatus: [CrewStatus]?
-    var crewStatus: [UserIdentifier: Status]
+    var crewStatus: [CrewStatus]?
+//    var crewStatus: [UserIdentifier: Status]
 }
 
 /**
@@ -107,10 +107,10 @@ var dummyCrewData: Crew? = Crew(
     inviteCode: "0101010",
     repeatDay: [1, 2, 3, 4, 5],
     sessionStatus: .waiting,
-//    crewStatus: [CrewStatus(name: "uni", profileColor: "blue", status: .waiting),
-//                 CrewStatus(name: "rei", profileColor: "red", status: .waiting),
-//                 CrewStatus(name: "bazzi", profileColor: "red", status: .waiting)]
-    crewStatus: ["uni": .waiting, "rei": .waiting]
+    crewStatus: [CrewStatus(name: "uni", profileColor: "blue", status: .waiting),
+                 CrewStatus(name: "rei", profileColor: "red", status: .waiting),
+                 CrewStatus(name: "bazzi", profileColor: "red", status: .waiting)]
+//    crewStatus: ["uni": .waiting, "rei": .waiting]
 )
 
 var dummyUserData: [User] = [

--- a/Carmu/Sources/Models/DTO/Crew.swift
+++ b/Carmu/Sources/Models/DTO/Crew.swift
@@ -107,9 +107,9 @@ var dummyCrewData: Crew? = Crew(
     inviteCode: "0101010",
     repeatDay: [1, 2, 3, 4, 5],
     sessionStatus: .waiting,
-    memberStatus: [MemeberStatus(nickname: "uni", profileColor: "blue", status: .waiting),
-                 MemeberStatus(nickname: "rei", profileColor: "red", status: .waiting),
-                 MemeberStatus(nickname: "bazzi", profileColor: "red", status: .waiting)]
+    memberStatus: [MemeberStatus(id: "000", nickname: "uni", profileColor: "blue", status: .waiting),
+                 MemeberStatus(id: "111", nickname: "rei", profileColor: "red", status: .waiting),
+                 MemeberStatus(id: "222", nickname: "bazzi", profileColor: "red", status: .waiting)]
 //    crewStatus: ["uni": .waiting, "rei": .waiting]
 )
 

--- a/Carmu/Sources/Models/DTO/Crew.swift
+++ b/Carmu/Sources/Models/DTO/Crew.swift
@@ -107,9 +107,9 @@ var dummyCrewData: Crew? = Crew(
     inviteCode: "0101010",
     repeatDay: [1, 2, 3, 4, 5],
     sessionStatus: .waiting,
-    crewStatus: [CrewStatus(name: "uni", profileColor: "blue", status: .waiting),
-                 CrewStatus(name: "rei", profileColor: "red", status: .waiting),
-                 CrewStatus(name: "bazzi", profileColor: "red", status: .waiting)]
+    crewStatus: [CrewStatus(nickname: "uni", profileColor: "blue", status: .waiting),
+                 CrewStatus(nickname: "rei", profileColor: "red", status: .waiting),
+                 CrewStatus(nickname: "bazzi", profileColor: "red", status: .waiting)]
 //    crewStatus: ["uni": .waiting, "rei": .waiting]
 )
 

--- a/Carmu/Sources/Models/DTO/CrewStatus.swift
+++ b/Carmu/Sources/Models/DTO/CrewStatus.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CrewStatus: Codable {
-    var name: String?
+    var nickname: String?
     var profileColor: String?
     var status: Status?
 }

--- a/Carmu/Sources/Models/DTO/CrewStatus.swift
+++ b/Carmu/Sources/Models/DTO/CrewStatus.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct CrewStatus: Codable {
+    var deviceToken: String?
     var nickname: String?
     var profileColor: String?
     var status: Status?

--- a/Carmu/Sources/Models/DTO/MemeberStatus.swift
+++ b/Carmu/Sources/Models/DTO/MemeberStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CrewStatus: Codable {
+struct MemeberStatus: Codable {
     var deviceToken: String?
     var nickname: String?
     var profileColor: String?

--- a/Carmu/Sources/Models/DTO/MemeberStatus.swift
+++ b/Carmu/Sources/Models/DTO/MemeberStatus.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct MemeberStatus: Codable {
+
+    var id: UserIdentifier?
     var deviceToken: String?
     var nickname: String?
     var profileColor: String?

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -431,18 +431,18 @@ extension FirebaseManager {
             }
         }
 
-        databaseRef.child("crewStatus").getData { error, snapshot in
+        databaseRef.child("memberStatus").getData { error, snapshot in
             if let error = error {
                 print(error.localizedDescription)
                 return
             }
 
-            if var crewStatus = snapshot?.value as? [String: String] {
-                crewStatus[userID] = Status.waiting.rawValue
-                databaseRef.child("crewStatus").setValue(crewStatus)
+            if var memberStatus = snapshot?.value as? [String: String] {
+                memberStatus[userID] = Status.waiting.rawValue
+                databaseRef.child("memberStatus").setValue(memberStatus)
             } else {
                 let newCrewStatus = [userID: Status.waiting.rawValue]
-                databaseRef.child("crewStatus").setValue(newCrewStatus)
+                databaseRef.child("memberStatus").setValue(newCrewStatus)
             }
         }
     }
@@ -512,7 +512,7 @@ extension FirebaseManager {
                 inviteCode: crewData["inviteCode"] as? String ?? "",
                 repeatDay: crewData["repeatDay"] as? [Int] ?? [1, 2, 3, 4, 5],
                 sessionStatus: crewData["sessionStatus"] as? Status ?? .waiting,
-                crewStatus: self.convertDataToCrewStatus(crewData["crewStatus"] as? [[String: Any]] ?? [])
+                memberStatus: self.convertDataToMemberStatus(crewData["memberStatus"] as? [[String: Any]] ?? [])
             )
 
             if crewData["stopover1"] != nil {
@@ -617,7 +617,7 @@ extension FirebaseManager {
                     inviteCode: crewData["inviteCode"] as? String ?? "",
                     repeatDay: crewData["repeatDay"] as? [Int] ?? [1, 2, 3, 4, 5],
 //                    crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
-                    crewStatus: self.convertDataToCrewStatus(crewData["crewStatus"] as? [[String: Any]] ?? [])
+                    memberStatus: self.convertDataToMemberStatus(crewData["memberStatus"] as? [[String: Any]] ?? [])
                 )
                 if crewData["stopover1"] != nil {
                     crew.stopover1 = self.convertDataToPoint(crewData["stopover1"] as? [String: Any] ?? [:])
@@ -659,8 +659,8 @@ extension FirebaseManager {
     }
 
     // Data를 CrewStatus로 불러옴
-    func convertDataToCrewStatus(_ data: [[String: Any]]) -> [CrewStatus] {
-        var crewStatusArray = [CrewStatus]()
+    func convertDataToMemberStatus(_ data: [[String: Any]]) -> [MemeberStatus] {
+        var crewStatusArray = [MemeberStatus]()
 
         for statusData in data {
             if let nickname = statusData["nickname"] as? String,
@@ -668,7 +668,7 @@ extension FirebaseManager {
                let profileColor = statusData["profileColor"] as? String,
                let statusString = statusData["status"] as? String,
                let statusEnum = Status(rawValue: statusString) {
-                let status = CrewStatus(deviceToken: deviceToken,
+                let status = MemeberStatus(deviceToken: deviceToken,
                                         nickname: nickname,
                                         profileColor: profileColor,
                                         status: statusEnum)

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -512,7 +512,8 @@ extension FirebaseManager {
                 inviteCode: crewData["inviteCode"] as? String ?? "",
                 repeatDay: crewData["repeatDay"] as? [Int] ?? [1, 2, 3, 4, 5],
                 sessionStatus: crewData["sessionStatus"] as? Status ?? .waiting,
-                crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
+//                crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
+                crewStatus: crewData["crewStatus"] as? [CrewStatus]
             )
 
             if crewData["stopover1"] != nil {
@@ -616,7 +617,8 @@ extension FirebaseManager {
                     destination: self.convertDataToPoint(crewData["destination"] as? [String: Any] ?? [:]),
                     inviteCode: crewData["inviteCode"] as? String ?? "",
                     repeatDay: crewData["repeatDay"] as? [Int] ?? [1, 2, 3, 4, 5],
-                    crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
+//                    crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
+                    crewStatus: crewData["crewStatus"] as? [CrewStatus]
                 )
                 if crewData["stopover1"] != nil {
                     crew.stopover1 = self.convertDataToPoint(crewData["stopover1"] as? [String: Any] ?? [:])

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -664,14 +664,16 @@ extension FirebaseManager {
 
         for statusData in data {
             if let nickname = statusData["nickname"] as? String,
+               let id = statusData["id"] as? String,
                let deviceToken = statusData["deviceToken"] as? String,
                let profileColor = statusData["profileColor"] as? String,
                let statusString = statusData["status"] as? String,
                let statusEnum = Status(rawValue: statusString) {
-                let status = MemeberStatus(deviceToken: deviceToken,
-                                        nickname: nickname,
-                                        profileColor: profileColor,
-                                        status: statusEnum)
+                let status = MemeberStatus(id: id,
+                                           deviceToken: deviceToken,
+                                           nickname: nickname,
+                                           profileColor: profileColor,
+                                           status: statusEnum)
                 crewStatusArray.append(status)
             }
         }

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -512,8 +512,7 @@ extension FirebaseManager {
                 inviteCode: crewData["inviteCode"] as? String ?? "",
                 repeatDay: crewData["repeatDay"] as? [Int] ?? [1, 2, 3, 4, 5],
                 sessionStatus: crewData["sessionStatus"] as? Status ?? .waiting,
-//                crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
-                crewStatus: crewData["crewStatus"] as? [CrewStatus]
+                crewStatus: self.convertDataToCrewStatus(crewData["crewStatus"] as? [[String: Any]] ?? [])
             )
 
             if crewData["stopover1"] != nil {
@@ -618,7 +617,7 @@ extension FirebaseManager {
                     inviteCode: crewData["inviteCode"] as? String ?? "",
                     repeatDay: crewData["repeatDay"] as? [Int] ?? [1, 2, 3, 4, 5],
 //                    crewStatus: crewData["crewStatus"] as? [UserIdentifier: Status] ?? [:]
-                    crewStatus: crewData["crewStatus"] as? [CrewStatus]
+                    crewStatus: self.convertDataToCrewStatus(crewData["crewStatus"] as? [[String: Any]] ?? [])
                 )
                 if crewData["stopover1"] != nil {
                     crew.stopover1 = self.convertDataToPoint(crewData["stopover1"] as? [String: Any] ?? [:])
@@ -659,15 +658,22 @@ extension FirebaseManager {
         return point
     }
 
-    func convertDataToCrewStatus(_ data: [String: Any]) -> CrewStatus {
-        var crewStatus = CrewStatus()
+    // Data를 CrewStatus로 불러옴
+    func convertDataToCrewStatus(_ data: [[String: Any]]) -> [CrewStatus] {
+        var crewStatusArray = [CrewStatus]()
 
-        crewStatus.name = data["name"] as? String
-        crewStatus.profileColor = data["profileColor"] as? String
-        crewStatus.status = data["status"] as? Status
-
-        return crewStatus
+        for statusData in data {
+            if let nickname = statusData["nickname"] as? String,
+               let profileColor = statusData["profileColor"] as? String,
+               let statusString = statusData["status"] as? String,
+               let statusEnum = Status(rawValue: statusString) {
+                let status = CrewStatus(nickname: nickname, profileColor: profileColor, status: statusEnum)
+                crewStatusArray.append(status)
+            }
+        }
+        return crewStatusArray
     }
+
 }
 
 extension FirebaseManager {

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -664,10 +664,14 @@ extension FirebaseManager {
 
         for statusData in data {
             if let nickname = statusData["nickname"] as? String,
+               let deviceToken = statusData["deviceToken"] as? String,
                let profileColor = statusData["profileColor"] as? String,
                let statusString = statusData["status"] as? String,
                let statusEnum = Status(rawValue: statusString) {
-                let status = CrewStatus(nickname: nickname, profileColor: profileColor, status: statusEnum)
+                let status = CrewStatus(deviceToken: deviceToken,
+                                        nickname: nickname,
+                                        profileColor: profileColor,
+                                        status: statusEnum)
                 crewStatusArray.append(status)
             }
         }

--- a/Carmu/Sources/Views/SessionStart/SessionStartDriverView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionStartDriverView.swift
@@ -161,7 +161,7 @@ final class DriverFrontView: UIView {
         return label
     }()
 
-    private let sessionStartVC = SessionStartViewController()
+    var crewData: Crew?
 
     init() {
         super.init(frame: .zero)
@@ -243,14 +243,11 @@ final class DriverFrontView: UIView {
     // TODO: - 실시간으로 어떻게 받아올 지 고민하기
     private func todayMemberJoined(crewData: Crew?) -> Int {
         guard let crewData = crewData, let memberStatus = crewData.memberStatus else { return 0 }
-
         // `memberStatus` 배열에서 `.accept` 상태인 요소들만 필터링하여 개수를 반환
         let todayJoiningMember = memberStatus.filter { $0.status == .accept }.count
 
         return todayJoiningMember
     }
-
-    var crewData: Crew?
 }
 
 // TODO: - 실제 데이터로 변경

--- a/Carmu/Sources/Views/SessionStart/SessionStartDriverView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionStartDriverView.swift
@@ -248,8 +248,8 @@ final class DriverFrontView: UIView {
 extension DriverFrontView: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        print("count ", crewData?.crewStatus?.count ?? 0)
-        return crewData?.crewStatus?.count ?? 0
+        print("count ", crewData?.memberStatus?.count ?? 0)
+        return crewData?.memberStatus?.count ?? 0
     }
 
     // TODO: - 여기부터 하기
@@ -325,12 +325,12 @@ extension DriverFrontView: UICollectionViewDelegateFlowLayout {
         let cellSpacing: CGFloat = 10 // 셀 간격
         let numberOfCellsPerRow: Int = 4 // 한 줄에 표시할 셀 개수
 
-        let totalCellWidth: CGFloat = CGFloat(dummyCrewData?.crewStatus?.count ?? 0) * cellWidth
-        let totalSpacing: CGFloat = CGFloat(dummyCrewData?.crewStatus?.count ?? 0 - 1) * cellSpacing
+        let totalCellWidth: CGFloat = CGFloat(dummyCrewData?.memberStatus?.count ?? 0) * cellWidth
+        let totalSpacing: CGFloat = CGFloat(dummyCrewData?.memberStatus?.count ?? 0 - 1) * cellSpacing
         let totalWidth: CGFloat = totalCellWidth + totalSpacing
         let horizontalInset: CGFloat
 
-        if dummyCrewData?.crewStatus?.count ?? 0 <= numberOfCellsPerRow {
+        if dummyCrewData?.memberStatus?.count ?? 0 <= numberOfCellsPerRow {
             // 4개 이하인 경우, 한 줄로 표시
             horizontalInset = (collectionView.frame.width - totalWidth) / 2
             return UIEdgeInsets(top: 50, left: horizontalInset, bottom: 0, right: horizontalInset)

--- a/Carmu/Sources/Views/SessionStart/SessionStartDriverView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionStartDriverView.swift
@@ -248,8 +248,8 @@ final class DriverFrontView: UIView {
 extension DriverFrontView: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        print("count ", crewData?.crewStatus.count ?? 0)
-        return crewData?.crewStatus.count ?? 0
+        print("count ", crewData?.crewStatus?.count ?? 0)
+        return crewData?.crewStatus?.count ?? 0
     }
 
     // TODO: - 여기부터 하기
@@ -262,31 +262,31 @@ extension DriverFrontView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         // crewStatus에서 현재 indexPath.row에 해당하는 크루의 상태 값을 가져옵니다.
-        let crewID = dummyUserData[indexPath.row].id  // 예: "uni"
-        if let crewStatus = dummyCrewData?.crewStatus[crewID] {
-            // 운전자가 응답을 하지 않은 상황이면 Zzz..이고, 응답을 했다면 미응답으로 표현합니다.
-            if dummyCrewData?.sessionStatus == .waiting, crewStatus.statusValue == "미응답" {
-                cell.statusLabel.text = "Zzz.."
-            } else {
-                cell.statusLabel.text = crewStatus.statusValue
-            }
-            cell.userNameLabel.text = crewID
-        }
-        cell.profileImageView.image = UIImage(profileImageColor: dummyUserData[indexPath.row].profileImageColor)
-
-        // TODO: - 실제 데이터로 변경
-        // 운전자가 당일 운전을 진행할 때 글자 색상 변경
-        if dummyCrewData?.sessionStatus == .accept {
-            if let crewStatus = dummyCrewData?.crewStatus[crewID] {
-                if crewStatus == .accept {  // 크루원이 함께 간다고 했을 때
-                    cell.statusLabel.textColor = UIColor.semantic.accPrimary
-                    cell.statusLabel.font = UIFont.carmuFont.subhead3
-                } else if crewStatus == .decline {  // 크루원이 함께 가지 않는다고 했을 떄
-                    cell.statusLabel.textColor = UIColor.semantic.negative
-                    cell.statusLabel.font = UIFont.carmuFont.subhead3
-                }
-            }
-        }
+//        let crewID = dummyUserData[indexPath.row].id  // 예: "uni"
+//        if let crewStatus = dummyCrewData?.crewStatus[crewID] {
+//            // 운전자가 응답을 하지 않은 상황이면 Zzz..이고, 응답을 했다면 미응답으로 표현합니다.
+//            if dummyCrewData?.sessionStatus == .waiting, crewStatus.statusValue == "미응답" {
+//                cell.statusLabel.text = "Zzz.."
+//            } else {
+//                cell.statusLabel.text = crewStatus.statusValue
+//            }
+//            cell.userNameLabel.text = crewID
+//        }
+//        cell.profileImageView.image = UIImage(profileImageColor: dummyUserData[indexPath.row].profileImageColor)
+//
+//        // TODO: - 실제 데이터로 변경
+//        // 운전자가 당일 운전을 진행할 때 글자 색상 변경
+//        if dummyCrewData?.sessionStatus == .accept {
+//            if let crewStatus = dummyCrewData?.crewStatus[crewID] {
+//                if crewStatus == .accept {  // 크루원이 함께 간다고 했을 때
+//                    cell.statusLabel.textColor = UIColor.semantic.accPrimary
+//                    cell.statusLabel.font = UIFont.carmuFont.subhead3
+//                } else if crewStatus == .decline {  // 크루원이 함께 가지 않는다고 했을 떄
+//                    cell.statusLabel.textColor = UIColor.semantic.negative
+//                    cell.statusLabel.font = UIFont.carmuFont.subhead3
+//                }
+//            }
+//        }
 
         return cell
     }
@@ -325,12 +325,12 @@ extension DriverFrontView: UICollectionViewDelegateFlowLayout {
         let cellSpacing: CGFloat = 10 // 셀 간격
         let numberOfCellsPerRow: Int = 4 // 한 줄에 표시할 셀 개수
 
-        let totalCellWidth: CGFloat = CGFloat(dummyCrewData?.crewStatus.count ?? 0) * cellWidth
-        let totalSpacing: CGFloat = CGFloat(dummyCrewData?.crewStatus.count ?? 0 - 1) * cellSpacing
+        let totalCellWidth: CGFloat = CGFloat(dummyCrewData?.crewStatus?.count ?? 0) * cellWidth
+        let totalSpacing: CGFloat = CGFloat(dummyCrewData?.crewStatus?.count ?? 0 - 1) * cellSpacing
         let totalWidth: CGFloat = totalCellWidth + totalSpacing
         let horizontalInset: CGFloat
 
-        if dummyCrewData?.crewStatus.count ?? 0 <= numberOfCellsPerRow {
+        if dummyCrewData?.crewStatus?.count ?? 0 <= numberOfCellsPerRow {
             // 4개 이하인 경우, 한 줄로 표시
             horizontalInset = (collectionView.frame.width - totalWidth) / 2
             return UIEdgeInsets(top: 50, left: horizontalInset, bottom: 0, right: horizontalInset)


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Feat: 새로운 기능을 추가

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

✅ crewStatus를 변경하였습니다.
    - crewStatus라는 단어가 크루의 상태를 나타내는 것으로 이해할 수도 있을 여지가 있어보여 변수명을 `memberStatus`로 변경하였습니다.
    - memberStatus의 형식을 `[Useridentifier: Status]` 에서 `[MemberStatus]`로 변경하였습니다.
    - 헷갈리시는 분이 계실까봐 확인하시라고 crewStatus는 주석 처리해놓았습니다. (삭제 가능)
 
✅ MemberStatus를 생성하였습니다.
    - 해당 식에는 id, deviceToken, nickname, profileColor, status가 있습니다.

❓Crew의 crews의 변수는 없어도 될 듯 합니다.
    - memeberStatus에 있는 크루원의 id값이 있기 때문에 굳이 필요하진 않을 것 같으나, 기능 개발 이후 추후에 리팩토링할 때 확인해주시면 감사하겠습니다.
 
✅ collectionView에 데이터를 로드하였습니다.
    - 받아온 데이터를 collectionView와 운전자 화면에 렌더링해주었습니다.
    - 다만 reloadData()를 통해 불러오고 있기 때문에, print를 출력해보면 두 번? 불러오고 있습니다. 동작 자체에는 문제가 없으나, 추후에 고민해보면 좋을 듯 합니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: N/A

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #244 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->


현재 Firebase에 올라와있는 데이터를 불러온 영상입니다.
데이터 형식은 Firebase를 통해 확인해보실 수 있습니다.

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/104834390/7ab0d5d2-ef05-4970-88ef-b348fd4bc6b7



