### PR TITLE
[Fix] 경유지 설정 뷰 관련 버그 수정

### DIFF
--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
@@ -23,6 +23,7 @@ struct PointLatLng {
 final class SelectDetailStopoverPointViewController: UIViewController {
 
     private let stopoverPointMapView = SelectDetailStopoverPointView()
+    private let loadingView = LoadingView()
     var addressSelectionHandler: ((AddressDTO) -> Void)?
     private var points: PointLatLng
     private var addressDTO = AddressDTO()
@@ -78,6 +79,12 @@ final class SelectDetailStopoverPointViewController: UIViewController {
         stopoverPointMapView.mapView.addCameraDelegate(delegate: self)
         stopoverPointMapView.backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
         stopoverPointMapView.saveButton.addTarget(self, action: #selector(saveButtonAction), for: .touchUpInside)
+
+        view.addSubview(loadingView)
+        loadingView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        loadingView.showLoadingView(showInterval: 1.5)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/StopoverPointSelectViewController.swift
@@ -12,7 +12,7 @@ final class StopoverPointSelectViewController: UIViewController {
     private let stopoverPointSelectView = StopoverPointSelectView()
     private var stopoverCount = 1
     var crewData: Crew
-    var pointList: [Point] = []
+    var pointList: [Point] = Array(repeating: Point(), count: 3)
 
     init(crewData: Crew) {
         self.crewData = crewData
@@ -39,10 +39,48 @@ final class StopoverPointSelectViewController: UIViewController {
             make.edges.equalToSuperview()
         }
     }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        // 뒤로 넘어왔을 때 stopoverCount 파악하여 Constraint를 다시 잡아주는 부분
+        switch stopoverCount {
+        case 1:
+            break
+        case 2:
+            stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
+                make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
+                make.bottom.equalTo(stopoverPointSelectView.stopover3).offset(30)
+                make.leading.equalTo(stopoverPointSelectView).inset(20)
+            }
+            showStopoverButton(sequence: 2, isHidden: false)
+        default:
+            stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
+                make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
+                make.bottom.equalTo(stopoverPointSelectView.nextButton.snp.top).offset(-30)
+                make.leading.equalTo(stopoverPointSelectView).inset(20)
+            }
+            showStopoverButton(sequence: 2, isHidden: false)
+            showStopoverButton(sequence: 3, isHidden: false)
+            stopoverPointSelectView.stopoverAddButton.isHidden = true
+        }
+    }
 }
 
 // MARK: - custom Method
 extension StopoverPointSelectViewController {
+
+    private func showStopoverButton(sequence: Int, isHidden: Bool) {
+        if sequence == 2 {
+            stopoverPointSelectView.stopover2.label.isHidden = isHidden
+            stopoverPointSelectView.stopover2.button.isHidden = isHidden
+            stopoverPointSelectView.stopover2.xButton.isHidden = isHidden
+        } else {
+            stopoverPointSelectView.stopover3.label.isHidden = isHidden
+            stopoverPointSelectView.stopover3.button.isHidden = isHidden
+            stopoverPointSelectView.stopover3.xButton.isHidden = isHidden
+        }
+    }
 
     private func addButtonTarget() {
         stopoverPointSelectView.nextButton.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
@@ -81,9 +119,7 @@ extension StopoverPointSelectViewController {
                 make.bottom.equalTo(stopoverPointSelectView.stopover3).offset(30)
                 make.leading.equalTo(stopoverPointSelectView).inset(20)
             }
-            stopoverPointSelectView.stopover2.label.isHidden = false
-            stopoverPointSelectView.stopover2.button.isHidden = false
-            stopoverPointSelectView.stopover2.xButton.isHidden = false
+            showStopoverButton(sequence: 2, isHidden: false)
             stopoverCount += 1
         } else {
             stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
@@ -92,9 +128,7 @@ extension StopoverPointSelectViewController {
                 make.leading.equalTo(stopoverPointSelectView).inset(20)
             }
             stopoverPointSelectView.stopoverAddButton.isHidden = true
-            stopoverPointSelectView.stopover3.label.isHidden = false
-            stopoverPointSelectView.stopover3.button.isHidden = false
-            stopoverPointSelectView.stopover3.xButton.isHidden = false
+            showStopoverButton(sequence: 3, isHidden: false)
             stopoverCount += 1
         }
     }
@@ -106,21 +140,21 @@ extension StopoverPointSelectViewController {
                 make.bottom.equalTo(stopoverPointSelectView.stopover3).offset(30)
                 make.leading.equalTo(stopoverPointSelectView).inset(20)
             }
-            stopoverPointSelectView.stopover3.label.isHidden = true
-            stopoverPointSelectView.stopover3.button.isHidden = true
-            stopoverPointSelectView.stopover3.xButton.isHidden = true
+            stopoverPointSelectView.stopover3.button.setTitle("     경유지 3 검색", for: .normal)
+            showStopoverButton(sequence: 3, isHidden: true)
             stopoverPointSelectView.stopoverAddButton.isHidden = false
             stopoverCount -= 1
+            crewData.stopover3 = nil
         } else {
             stopoverPointSelectView.colorLine.snp.remakeConstraints { make in
                 make.top.equalTo(stopoverPointSelectView.titleLabel5.snp.bottom).offset(30)
                 make.bottom.equalTo(stopoverPointSelectView.stopover2).offset(30)
                 make.leading.equalToSuperview().inset(20)
             }
-            stopoverPointSelectView.stopover2.label.isHidden = true
-            stopoverPointSelectView.stopover2.button.isHidden = true
-            stopoverPointSelectView.stopover2.xButton.isHidden = true
+            stopoverPointSelectView.stopover2.button.setTitle("     경유지 2 검색", for: .normal)
+            showStopoverButton(sequence: 2, isHidden: true)
             stopoverCount -= 1
+            crewData.stopover2 = nil
         }
     }
 


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해

경유지 설정 뷰 자체를 테이블뷰로 변경하려 했으나, 코드 변경으로 인한 코드 작업 시간이 길어질 것 같아 기존의 방식 중 문제였던 뒤로 오기를 눌렀을 때, 레이아웃이 깨지는 문제를 해결했습니다.
또한 2번 경유지부터 넣었을 때, index out of range 런타임 오류가 뜨는 문제를 해결했습니다.

로딩뷰도 집어넣었습니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: N/A

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #276 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
![Simulator Screen Recording - iPhone 15 Pro Max - 2023-11-18 at 22 28 16](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/7291b9d8-9756-4f1d-ab11-c8ad53626219)
