### PR TITLE
[Feat] 시간 선택 뷰 이전 장소보다 더 늦은 시간으로만 설정되는 기능 추가

### DIFF
--- a/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
@@ -27,7 +27,6 @@ final class BoardingPointSelectViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.backButtonTitle = ""
         view.layer.insertSublayer(CrewMakeUtil.backGroundLayer(view), at: 0)
 
         boardingPointSelectView.customTableVieWCell = {

--- a/Carmu/Sources/Controllers/CrewMake/Driver/CodeShareViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/CodeShareViewController.swift
@@ -25,7 +25,6 @@ final class CodeShareViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.backButtonTitle = ""
         view.layer.insertSublayer(CrewMakeUtil.backGroundLayer(view), at: 0)
         addRightBarButton()
 

--- a/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectModalViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectModalViewController.swift
@@ -13,6 +13,7 @@ final class TimeSelectModalViewController: UIViewController {
     var timeSelectionHandler: ((Date) -> Void)?
     private var selectedTime: Date?
     weak var timeSelectViewController: TimeSelectViewController?
+    private var isPickerChanging = false
 
     override var sheetPresentationController: UISheetPresentationController? {
         presentationController as? UISheetPresentationController
@@ -34,6 +35,7 @@ final class TimeSelectModalViewController: UIViewController {
         sheetPresentationController?.delegate = self
         sheetPresentationController?.prefersGrabberVisible = true
         sheetPresentationController?.detents = [.medium()]
+        // 타임 피커의 동작 여부를 감지하는 옵저버 추가
     }
 }
 
@@ -49,8 +51,15 @@ extension TimeSelectModalViewController {
         dismiss(animated: true)
     }
 
+    @objc private func timePickerValueStartChange() {
+        timeSelectModalView.saveButton.isEnabled = true
+        timeSelectModalView.saveButton.backgroundColor = UIColor.semantic.accPrimary
+    }
+
     @objc private func timePickerValueChanged() {
         selectedTime = timeSelectModalView.timePicker.date
+        timeSelectModalView.saveButton.isEnabled = true
+        timeSelectModalView.saveButton.backgroundColor = UIColor.semantic.accPrimary
     }
 }
 

--- a/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
@@ -143,7 +143,12 @@ extension TimeSelectViewController {
 
         // TODO: - Crew에 정보 입력하는 방식 이후, 타임 피커에 이전 경유지보다 늦은 시간부터 설정하는 로직 구현예정
         if sender.tag > 0 {
+            let lastTime = Date.formattedDate(
+                string: timeSelectView.customTableVieWCell[sender.tag - 1].detailTimeButton.titleLabel?.text ?? "오전 12:00",
+                dateFormat: "aa hh:mm"
+            ) ?? Date()
 
+            detailViewController.timeSelectModalView.timePicker.minimumDate = lastTime
         }
         detailViewController.timeSelectModalView.timePicker.date = Date.formattedDate(
             string: timeSelectView.customTableVieWCell[sender.tag].detailTimeButton.titleLabel?.text ?? "오전 12:00",

--- a/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/TimeSelect/TimeSelectViewController.swift
@@ -141,15 +141,17 @@ extension TimeSelectViewController {
     @objc private func setTimeButtonTapped(_ sender: UIButton) {
         let detailViewController = TimeSelectModalViewController()
 
-        // TODO: - Crew에 정보 입력하는 방식 이후, 타임 피커에 이전 경유지보다 늦은 시간부터 설정하는 로직 구현예정
+        // 출발지가 아닌 경우, 타임 피커의 최소 시간을 설정하는 조건문
         if sender.tag > 0 {
             let lastTime = Date.formattedDate(
                 string: timeSelectView.customTableVieWCell[sender.tag - 1].detailTimeButton.titleLabel?.text ?? "오전 12:00",
                 dateFormat: "aa hh:mm"
             ) ?? Date()
-
             detailViewController.timeSelectModalView.timePicker.minimumDate = lastTime
+            detailViewController.timeSelectModalView.saveButton.isEnabled = false
+            detailViewController.timeSelectModalView.saveButton.backgroundColor = UIColor.semantic.backgroundThird
         }
+
         detailViewController.timeSelectModalView.timePicker.date = Date.formattedDate(
             string: timeSelectView.customTableVieWCell[sender.tag].detailTimeButton.titleLabel?.text ?? "오전 12:00",
             dateFormat: "aa hh:mm"
@@ -158,13 +160,6 @@ extension TimeSelectViewController {
         // 클로저를 통해 선택한 시간을 받음
         detailViewController.timeSelectionHandler = { [weak self] selectedTime in
             self?.updateDetailTime(at: sender.tag, with: selectedTime)
-
-            // 현재 선택지 이후의 시간을 자동으로 10분 간격으로 미뤄주는 부분
-            var index = 1
-            for element in sender.tag + 1..<(self?.timeSelectView.customTableVieWCell.count ?? 0) {
-                self?.updateDetailTime(at: element, with: selectedTime + TimeInterval(600 * index))
-                index += 1
-            }
         }
         present(detailViewController, animated: true)
     }

--- a/Carmu/Sources/Controllers/CrewMake/PositionSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/PositionSelectViewController.swift
@@ -13,6 +13,7 @@ final class PositionSelectViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationItem.backButtonTitle = ""
         view.layer.insertSublayer(CrewMakeUtil.backGroundLayer(view), at: 0)
 
         positionSelectView.selectDriverButton.addTarget(

--- a/Carmu/Sources/Views/CrewMake/Driver/TimeSelect/TimeSelectModalView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/TimeSelect/TimeSelectModalView.swift
@@ -20,7 +20,7 @@ final class TimeSelectModalView: UIView {
 
     private let subtitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "해당 위치의 출발 또는 도착 예정 시간을 변경합니다"
+        label.text = "이전 장소보다 더 늦은 시간이어야 설정할 수 있어요."
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor.gray
         label.numberOfLines = 0


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Feat: 새로운 기능을 추가
- [x] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

이전 장소 시간보다 더 이른 시간을 설정되지 못하도록 변경했습니다.
더불어 셔틀 이름 입력뷰와 공유 코드 뷰에서 백버튼의 타이틀이 나타나는 현상을 수정했습니다.
레이 코드에서도 동일하게 작동합니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: N/A

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #318 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
![Simulator Screen Recording - iPhone 15 Pro Max - 2023-11-23 at 00 38 51](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/98330884/61242c77-aeb5-4ac8-9fe9-13d27a1d2fae)
