### PR TITLE
[Fix] 크루 편집 시 주소 설정 지도뷰 교체

### DIFF
--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
@@ -157,17 +157,52 @@ extension SelectDetailStopoverPointViewController {
         switch pointType {
         case .start:
             cameraUpdate = NMFCameraUpdate(scrollTo: points.startingPoint)
+            getAddressAndBuildingName(points.startingPoint) { buildingName, detailAddress in
+                // 주소와 건물명을 업데이트
+                DispatchQueue.main.async {
+                    self.stopoverPointMapView.buildingNameLabel.text = buildingName
+                    self.stopoverPointMapView.detailAddressLabel.text = detailAddress
+                }
+            }
         case .destination:
             cameraUpdate = NMFCameraUpdate(scrollTo: points.destination)
+            getAddressAndBuildingName(points.destination) { buildingName, detailAddress in
+                // 주소와 건물명을 업데이트
+                DispatchQueue.main.async {
+                    self.stopoverPointMapView.buildingNameLabel.text = buildingName
+                    self.stopoverPointMapView.detailAddressLabel.text = detailAddress
+                }
+            }
         case .stopover1:
             guard let pickupLocation1 = points.pickupLocation1 else { return }
             cameraUpdate = NMFCameraUpdate(scrollTo: pickupLocation1)
+            getAddressAndBuildingName(pickupLocation1) { buildingName, detailAddress in
+                // 주소와 건물명을 업데이트
+                DispatchQueue.main.async {
+                    self.stopoverPointMapView.buildingNameLabel.text = buildingName
+                    self.stopoverPointMapView.detailAddressLabel.text = detailAddress
+                }
+            }
         case .stopover2:
             guard let pickupLocation2 = points.pickupLocation2 else { return }
             cameraUpdate = NMFCameraUpdate(scrollTo: pickupLocation2)
+            getAddressAndBuildingName(pickupLocation2) { buildingName, detailAddress in
+                // 주소와 건물명을 업데이트
+                DispatchQueue.main.async {
+                    self.stopoverPointMapView.buildingNameLabel.text = buildingName
+                    self.stopoverPointMapView.detailAddressLabel.text = detailAddress
+                }
+            }
         case .stopover3:
             guard let pickupLocation3 = points.pickupLocation3 else { return }
             cameraUpdate = NMFCameraUpdate(scrollTo: pickupLocation3)
+            getAddressAndBuildingName(pickupLocation3) { buildingName, detailAddress in
+                // 주소와 건물명을 업데이트
+                DispatchQueue.main.async {
+                    self.stopoverPointMapView.buildingNameLabel.text = buildingName
+                    self.stopoverPointMapView.detailAddressLabel.text = detailAddress
+                }
+            }
         }
         stopoverPointMapView.mapView.moveCamera(cameraUpdate)
     }

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
@@ -22,12 +22,14 @@ struct PointLatLng {
 
 final class SelectDetailStopoverPointViewController: UIViewController {
 
-    private let stopoverPointMapView = SelectDetailStopoverPointView()
+    let stopoverPointMapView = SelectDetailStopoverPointView()
     private let loadingView = LoadingView()
     var addressSelectionHandler: ((AddressDTO) -> Void)?
     private var points: PointLatLng
     private var addressDTO = AddressDTO()
-    private var currentLatLng: NMGLatLng?
+    var currentLatLng: NMGLatLng?
+    var isCrewEdit: Bool = false // 크루 편집 시 넘어온 화면인지 체크
+    var pointType: PointType = .stopover1 // 출발지~경유지~도착지 중 어느 포인트인지
 
     init(crewData: Crew) {
         self.points = PointLatLng(

--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointViewController.swift
@@ -90,7 +90,7 @@ final class SelectDetailStopoverPointViewController: UIViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        mapBoundSetting()
+        mapBoundSettingCheck(isEdit: isCrewEdit)
         stopoverPointMapView.showExplain()
     }
 }
@@ -103,7 +103,6 @@ extension SelectDetailStopoverPointViewController {
     }
 
     @objc private func saveButtonAction() {
-        // TODO: 데이터 전달 구현
         addressDTO.pointName = stopoverPointMapView.buildingNameLabel.text
         addressDTO.pointDetailAddress = stopoverPointMapView.detailAddressLabel.text
         addressDTO.pointLat = currentLatLng?.lat
@@ -124,8 +123,17 @@ extension SelectDetailStopoverPointViewController {
         fetchDirections()
     }
 
+    // 크루 편집 여부에 따라 카메라 업데이트를 다르게 처리
+    func mapBoundSettingCheck(isEdit: Bool = false) {
+        if isEdit {
+            mapBoundSettingForEdit(pointType: pointType)
+        } else {
+            mapBoundSetting()
+        }
+    }
     /**
      출발, 도착, 경유지를 한 화면에 표시할 수 있는 영역을 보이도록 CameraUpdate 하는 메서드
+     -  bounds의 중앙으로 잡아주는 경우 (기본)
      */
     private func mapBoundSetting() {
         let bounds = mapBoundsForPoints(points: points)
@@ -140,6 +148,28 @@ extension SelectDetailStopoverPointViewController {
                 self.stopoverPointMapView.detailAddressLabel.text = detailAddress
             }
         }
+    }
+    /**
+     - 해당하는 기존 포인트 위치로 카메라 업데이트 (크루 편집 시)
+     */
+    private func mapBoundSettingForEdit(pointType: PointType) {
+        let cameraUpdate: NMFCameraUpdate
+        switch pointType {
+        case .start:
+            cameraUpdate = NMFCameraUpdate(scrollTo: points.startingPoint)
+        case .destination:
+            cameraUpdate = NMFCameraUpdate(scrollTo: points.destination)
+        case .stopover1:
+            guard let pickupLocation1 = points.pickupLocation1 else { return }
+            cameraUpdate = NMFCameraUpdate(scrollTo: pickupLocation1)
+        case .stopover2:
+            guard let pickupLocation2 = points.pickupLocation2 else { return }
+            cameraUpdate = NMFCameraUpdate(scrollTo: pickupLocation2)
+        case .stopover3:
+            guard let pickupLocation3 = points.pickupLocation3 else { return }
+            cameraUpdate = NMFCameraUpdate(scrollTo: pickupLocation3)
+        }
+        stopoverPointMapView.mapView.moveCamera(cameraUpdate)
     }
 
     private func mapBoundsForPoints(points: PointLatLng) -> NMGLatLngBounds {

--- a/Carmu/Sources/Controllers/MyPage/CrewEdit/CrewEditViewController.swift
+++ b/Carmu/Sources/Controllers/MyPage/CrewEdit/CrewEditViewController.swift
@@ -8,6 +8,7 @@
 import MapKit
 import UIKit
 
+import NMapsMap
 import SnapKit
 
 // MARK: - 크루 편집 완료 시 이전 뷰 컨트롤러에 데이터를 넘겨주기 위한 델리게이트 프로토콜
@@ -309,36 +310,19 @@ extension CrewEditViewController: PointEditTableViewCellDelegate {
         present(timeSelectModalVC, animated: true)
     }
 
-    // MARK: - 주소 설정 버튼 클릭 시 호출되는 델리게이트 메서드
+    // MARK: - 주소 편집 버튼 클릭 시 호출되는 델리게이트 메서드
     func addressEditButtonTapped(sender: AddressEditButton) {
-        let detailPointMapVC = SelectDetailPointMapViewController() // 출발지, 도착지 상세주소 설정
-//        let detailStopoverPointMapVC = SelectDetailStopoverPointViewController(crewData: newUserCrewData) // 경유지 상세주소 설정
-        // 상세주소 설정 뷰컨트롤러에 넘겨줄 기존 주소값
-        var originalPointData = SelectAddressDTO(pointName: sender.pointType?.rawValue)
+        let detailPointMapVC = SelectDetailStopoverPointViewController(crewData: newUserCrewData)
+        detailPointMapVC.isCrewEdit = true
+        detailPointMapVC.pointType = sender.pointType ?? .stopover1
         switch sender.pointType {
         case .start:
-            originalPointData.buildingName = newUserCrewData.startingPoint?.name
-            originalPointData.detailAddress = newUserCrewData.startingPoint?.detailAddress
-            originalPointData.coordinate = CLLocationCoordinate2D(
-                latitude: newUserCrewData.startingPoint?.latitude ?? 35.634,
-                longitude: newUserCrewData.startingPoint?.longitude ?? 128.523
-            )
+            detailPointMapVC.stopoverPointMapView.saveButton.setTitle("출발지로 설정", for: .normal)
         case .destination:
-            originalPointData.buildingName = newUserCrewData.destination?.name
-            originalPointData.detailAddress = newUserCrewData.destination?.detailAddress
-            originalPointData.coordinate = CLLocationCoordinate2D(
-                latitude: newUserCrewData.destination?.latitude ?? 35.634,
-                longitude: newUserCrewData.destination?.longitude ?? 128.523
-            )
+            detailPointMapVC.stopoverPointMapView.saveButton.setTitle("도착지로 설정", for: .normal)
         default:
-            originalPointData.buildingName = stopoverPoints[sender.pointType?.stopoverIdx ?? -1]?.name
-            originalPointData.detailAddress = stopoverPoints[sender.pointType?.stopoverIdx ?? -1]?.detailAddress
-            originalPointData.coordinate = CLLocationCoordinate2D(
-                latitude: stopoverPoints[sender.pointType?.stopoverIdx ?? -1]?.latitude ?? 35.634,
-                longitude: stopoverPoints[sender.pointType?.stopoverIdx ?? -1]?.longitude ?? 128.523
-            )
+            break
         }
-        detailPointMapVC.selectAddressModel = originalPointData
 
         // 주소 설정 시 테이블뷰 UI 및 newUserCrewData에 반영
         detailPointMapVC.addressSelectionHandler = { newPointData in
@@ -373,13 +357,6 @@ extension CrewEditViewController: PointEditTableViewCellDelegate {
             print("✅stopover2: \(String(describing: self.newUserCrewData.stopover2))")
             print("✅stopover3: \(String(describing: self.newUserCrewData.stopover3))")
             print("✅destination: \(String(describing: self.newUserCrewData.destination))")
-        }
-        if sender.pointType == .destination {
-            detailPointMapVC.selectDetailPointMapView.saveButton.setTitle("도착지로 설정", for: .normal)
-        } else if sender.pointType == .start {
-            detailPointMapVC.selectDetailPointMapView.saveButton.setTitle("출발지로 설정", for: .normal)
-        } else {
-            detailPointMapVC.selectDetailPointMapView.saveButton.setTitle("경유지로 설정", for: .normal)
         }
         present(detailPointMapVC, animated: true)
     }


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] Feat: 새로운 기능을 추가
- [X] Fix: 버그 수정
- [X] Design: CSS 등 사용자 UI 디자인 변경

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

### ✅ 크루 편집 시 주소를 설정해주는 지도뷰를 교체했습니다.
- `SelectDetailPointMapViewController` 👉 `SelectDetailStopoverPointViewController`로 교체했습니다.
- 출발지, 도착지, 경유지마다 하단의 버튼 텍스트가 다르게 나오도록 했습니다.
- 주소 설정 뷰 진입 시 경로가 그려진 상태에서 선택한 포인트의 좌표가 카메라 중앙으로 맞춰지도록 했습니다.

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/19789237-4913-43b8-9e87-f030bd8bd465

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #320

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #320

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

