### PR TITLE
[Fix] 탑승자가 포기하기 버튼 눌렀을 때 세션이 종료되어버림

### DIFF
--- a/Carmu/Sources/Controllers/Map/MapViewController.swift
+++ b/Carmu/Sources/Controllers/Map/MapViewController.swift
@@ -314,8 +314,13 @@ extension MapViewController {
                 self.serverPushManager.sendGiveupToPassenger(crew: self.crew)
             }
 
-            self.updateSessionStatus(to: .waiting)
-            self.firebaseManager.resetSessionData(crew: self.crew)
+            if self.isDriver {
+                self.updateSessionStatus(to: .waiting)
+                self.firebaseManager.resetSessionData(crew: self.crew)
+            } else {
+                // TODO: - MemberStatus를 giveUp으로 변경
+                self.firebaseManager.updateMemberStatus(crewData: self.crew, status: .decline)
+            }
             self.dismiss(animated: true)
         }
         alert.addAction(cancelAction)

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -702,40 +702,30 @@ extension FirebaseManager {
 // MARK: - SessionStartView Actions
 extension FirebaseManager {
 
+    /// 나(키체인에 등록된 UserIdenfier)의 MemberStatus를 변경해주는 메서드
+    func updateMemberStatus(crewData: Crew?, status: Status) {
+        guard let crewData = crewData,
+              let crewID = crewData.id,
+              let memberStatus = crewData.memberStatus else {
+            return
+        }
+
+        for (index, member) in memberStatus.enumerated() {
+            guard member.id == KeychainItem.currentUserIdentifier else {
+                continue
+            }
+            Database.database().reference().child("crew/\(crewID)/memberStatus/\(index)/status").setValue(status)
+        }
+    }
+
     // 따로가요 클릭 시 해당 동승자의 status decline으로 변경
     func passengerIndividualButtonTapped(crewData: Crew?) {
-
-        guard let crewData = crewData else { return }
-        guard let memberStatus = crewData.memberStatus else { return }
-
-        for (index, member) in memberStatus.enumerated() where member.id == KeychainItem.currentUserIdentifier {
-            if let crewID = crewData.id {
-                let statusRef = Database.database().reference().child("crew/\(crewID)/memberStatus/\(index)/status")
-                statusRef.setValue(Status.decline.rawValue) { error, _ in
-                    if let error = error {
-                        print("Error occured: ", error)
-                    }
-                }
-            }
-        }
+        updateMemberStatus(crewData: crewData, status: .decline)
     }
 
     // 함께가요 클릭 시 해당 동승자의 status accept로 변경
     func passengerTogetherButtonTapped(crewData: Crew?) {
-        guard let crewData = crewData else { return }
-        guard let memberStatus = crewData.memberStatus else { return }
-
-        for (index, member) in memberStatus.enumerated() where member.id == KeychainItem.currentUserIdentifier {
-            if let crewID = crewData.id {
-                let statusRef = Database.database().reference().child("crew/\(crewID)/memberStatus/\(index)/status")
-
-                statusRef.setValue(Status.accept.rawValue) { error, _ in
-                    if let error = error {
-                        print("Error occured: ", error)
-                    }
-                }
-            }
-        }
+        updateMemberStatus(crewData: crewData, status: .accept)
     }
 
     /// Crew의 sessionStatus를 변경하는 메서드


### PR DESCRIPTION
- 탑승자의 MemberStatus만 decline으로 변경하는 수정

## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Fix: 버그 수정
- [x] Refactor: 프로덕션 코드 리팩토링

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

맵뷰에서 운전자가 아닌 탑승자가 포기하기 버튼을 눌렀을 때 세션이 종료되어버리는 버그가 있어 수정했습니다.

### 포기하기 버튼 선택시

🔴BEFORE
[운전자, 탑승자] 세션 종료

🟢AFTER
[운전자] 세션 종료
[탑승자] 해당 유저의 MemberStatus만 decline으로 변경

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #336 

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #336 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
