### PR TITLE
[Fix] StartView에서 SessionStatus가 sessionStart, MemberStatus가 decline일 때 버튼 버그 수정

### DIFF
--- a/Carmu/Sources/Views/SessionStart/SessionStartView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionStartView.swift
@@ -465,7 +465,7 @@ extension SessionStartView {
 
     private func setBottomButtonMemberDecline(crewData: Crew) {
         individualButton.showButton(title: "따로가요", enabled: false)
-        if crewData.sessionStatus == .decline {
+        if crewData.sessionStatus == .decline || crewData.sessionStatus == .sessionStart {
             togetherButton.showButton(title: "함께가요", enabled: false)
         } else {
             togetherButton.showButton(title: "함께가요", buttonColor: UIColor.semantic.accPrimary)


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

SessionStatus가 sessionStart일 때 MemberStatus가 decline이면 함께가요 버튼이 활성화 되어있는데, 비활성화되도록 변경

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #335 

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #335 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
