### PR TITLE
[Fix] 초대코드 입력 시 유효하지 않은 초대코드 입력해도 넘어가는 문제

### DIFF
--- a/Carmu/Sources/Controllers/CrewMake/Crew/InviteCodeInputViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/InviteCodeInputViewController.swift
@@ -12,6 +12,7 @@ final class InviteCodeInputViewController: UIViewController {
     private let inviteCodeInputView = InviteCodeInputView()
     private let firebaseManager = FirebaseManager()
     private var crewData = Crew(memberStatus: [MemberStatus]())
+    var isCrewExist = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -95,9 +96,11 @@ extension InviteCodeInputViewController {
                     self.inviteCodeInputView.nextButton.isEnabled = true
                     self.inviteCodeInputView.nextButton.backgroundColor = UIColor.semantic.accPrimary
                     self.crewData = crewData
+                    self.isCrewExist = true
                 } else {
                     self.inviteCodeInputView.conformCodeLabel.isHidden = true
                     self.inviteCodeInputView.rejectCodeLabel.isHidden = false
+                    self.isCrewExist = false
                 }
             }
         } else {
@@ -105,6 +108,7 @@ extension InviteCodeInputViewController {
             self.inviteCodeInputView.rejectCodeLabel.isHidden = true
             self.inviteCodeInputView.nextButton.isEnabled = false
             self.inviteCodeInputView.nextButton.backgroundColor = UIColor.semantic.backgroundThird
+            self.isCrewExist = false
         }
     }
 
@@ -141,8 +145,12 @@ extension InviteCodeInputViewController {
 extension InviteCodeInputViewController: UITextFieldDelegate {
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        nextButtonTapped()
-        return true
+        if isCrewExist {
+            nextButtonTapped()
+            return true
+        } else {
+            return false
+        }
     }
 }
 

--- a/Carmu/Sources/Views/CrewMake/Crew/InviteCodeInputView.swift
+++ b/Carmu/Sources/Views/CrewMake/Crew/InviteCodeInputView.swift
@@ -16,31 +16,32 @@ final class InviteCodeInputView: UIView {
 
     // MARK: - 텍스트 필드 배경
     private lazy var codeSearchTextFieldView: UIView = {
-        let friendSearchTextFieldView = UIView()
-        friendSearchTextFieldView.layer.cornerRadius = 20
-        friendSearchTextFieldView.layer.borderWidth = 1.0
-        friendSearchTextFieldView.layer.borderColor = UIColor.theme.blue3?.cgColor
-        return friendSearchTextFieldView
+        let codeSearchTextFieldView = UIView()
+        codeSearchTextFieldView.layer.cornerRadius = 20
+        codeSearchTextFieldView.layer.borderWidth = 1.0
+        codeSearchTextFieldView.layer.borderColor = UIColor.theme.blue3?.cgColor
+        return codeSearchTextFieldView
     }()
 
     // MARK: - 텍스트 필드
     lazy var codeSearchTextField: UITextField = {
-        let friendSearchTextField = UITextField()
-        friendSearchTextField.textAlignment = .left
-        friendSearchTextField.font = UIFont.carmuFont.body2Long
-        friendSearchTextField.textColor = UIColor.semantic.textPrimary
-        friendSearchTextField.autocapitalizationType = .none
+        let codeSearchTextField = UITextField()
+        codeSearchTextField.textAlignment = .left
+        codeSearchTextField.font = UIFont.carmuFont.body2Long
+        codeSearchTextField.textColor = UIColor.semantic.textPrimary
+        codeSearchTextField.autocapitalizationType = .none
+        codeSearchTextField.enablesReturnKeyAutomatically = true
 
         let placeholderAttributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: UIColor.semantic.textPrimary as Any,
             .font: UIFont.carmuFont.body2Long
         ]
-        friendSearchTextField.attributedPlaceholder = NSAttributedString(
+        codeSearchTextField.attributedPlaceholder = NSAttributedString(
             string: "초대코드를 입력하세요",
             attributes: placeholderAttributes
         )
 
-        return friendSearchTextField
+        return codeSearchTextField
     }()
 
     // MARK: - 텍스트 필드 clear 버튼


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

### ✅ 크루가 유효할 때만 키보드의 [search] 버튼이 동작하도록 했습니다.
- 추가로 입력된 텍스트가 없을 때는 search키를 비활성화시키는 옵션을 추가했습니다.
  - 크루가 검색됐을때만 활성화되도록 하고 싶은데, 관련 옵션을 못찾아서 일단 이렇게나마 처리해놨습니다🤔 어차피 크루 데이터가 없을 때는 search 버튼을 눌러도 동작하지 않도록 막아놔서 문제는 없을 것 같습니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #351

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #351

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->


https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/2f28e059-a588-4145-8db8-aaba3ff43035

