### PR TITLE
[Feat] 셔틀이 운행되지 않는 요일일 때 화면 구현

### DIFF
--- a/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
+++ b/Carmu/Sources/Controllers/SessionStart/SessionStartViewController.swift
@@ -25,6 +25,12 @@ final class SessionStartViewController: UIViewController {
         }
     }
 
+    var isValidDay: Bool {
+        guard let repeatDay = crewData?.repeatDay else { return false }
+        guard let today = DayOfWeek.stringToInt(Date().toDay) else { return false }
+        return repeatDay.contains(today)
+    }
+
     init(crewData: Crew? = nil) {
         self.crewData = crewData
         super.init(nibName: nil, bundle: nil)
@@ -124,6 +130,11 @@ extension SessionStartViewController {
             make.edges.equalToSuperview()
         }
 
+        guard isValidDay else {
+            setCardDriverDecline()
+            return
+        }
+
         // 운행하지 않아요 카드를 보여주거나 숨기는 부분
         switch crewData.sessionStatus {
         case .waiting:
@@ -133,10 +144,14 @@ extension SessionStartViewController {
             backgroundView.driverCardView.driverFrontView.noDriveViewForDriver.isHidden = true
             backgroundView.driverCardView.layer.opacity = 1.0
         case .decline:
-            backgroundView.driverCardView.driverFrontView.noDriveViewForDriver.isHidden = false
-            backgroundView.driverCardView.layer.opacity = 1.0
+            setCardDriverDecline()
         case .none: break
         }
+    }
+
+    private func setCardDriverDecline() {
+        backgroundView.driverCardView.driverFrontView.noDriveViewForDriver.isHidden = false
+        backgroundView.driverCardView.layer.opacity = 1.0
     }
 
     private func setCardForMember(crewData: Crew) {
@@ -146,6 +161,11 @@ extension SessionStartViewController {
         backgroundView.cardView.addSubview(backgroundView.memberCardView)
         backgroundView.memberCardView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+
+        guard isValidDay else {
+            setCardMemberDecline()
+            return
         }
 
         // 운행하지 않아요 카드를 보여주거나 숨기는 부분
@@ -166,16 +186,20 @@ extension SessionStartViewController {
                 backgroundView.memberCardView.passengerFrontView.noDriveViewForPassenger.isHidden = false
             }
         case .decline:
-            backgroundView.memberCardView.passengerFrontView.noDriveViewForPassenger.isHidden = false
-            backgroundView.memberCardView.passengerFrontView.noDriveComment.text = "오늘은 셔틀이 운행되지 않아요"
-            backgroundView.memberCardView.passengerFrontView.noDriveComment.textColor = UIColor.semantic.negative
-            backgroundView.driverCardView.layer.opacity = 1.0
+            setCardMemberDecline()
         case .sessionStart:
             backgroundView.memberCardView.passengerFrontView.statusImageView.image = UIImage(named: "DriverBlinker")
             backgroundView.memberCardView.passengerFrontView.statusLabel.text = "오늘은 셔틀이 운행될 예정이에요"
             backgroundView.driverCardView.layer.opacity = 1.0
         case .none: break
         }
+    }
+
+    private func setCardMemberDecline() {
+        backgroundView.memberCardView.passengerFrontView.noDriveViewForPassenger.isHidden = false
+        backgroundView.memberCardView.passengerFrontView.noDriveComment.text = "오늘은 셔틀이 운행되지 않아요"
+        backgroundView.memberCardView.passengerFrontView.noDriveComment.textColor = UIColor.semantic.negative
+        backgroundView.driverCardView.layer.opacity = 1.0
     }
 }
 

--- a/Carmu/Sources/Extensions/Date+Extension.swift
+++ b/Carmu/Sources/Extensions/Date+Extension.swift
@@ -40,4 +40,16 @@ extension Date {
         dateFormatter.locale = Locale(identifier: "ko_KR")
         return dateFormatter.string(from: self)
     }
+
+    /**
+     요일을 반환
+     ex) "월", "화", "수", "목", "금", "토", "일"
+     */
+    var toDay: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "EEEEE"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.timeZone = .autoupdatingCurrent
+        return dateFormatter.string(from: self)
+    }
 }

--- a/Carmu/Sources/Models/DayOfWeek.swift
+++ b/Carmu/Sources/Models/DayOfWeek.swift
@@ -32,3 +32,18 @@ enum DayOfWeek: Int {
         }
     }
 }
+
+extension DayOfWeek {
+    static func stringToInt(_ string: String) -> Int? {
+        switch string {
+        case "월": return 0
+        case "화": return 1
+        case "수": return 2
+        case "목": return 3
+        case "금": return 4
+        case "토": return 5
+        case "일": return 6
+        default: return nil
+        }
+    }
+}

--- a/Carmu/Sources/Views/SessionStart/SessionStartView.swift
+++ b/Carmu/Sources/Views/SessionStart/SessionStartView.swift
@@ -141,11 +141,22 @@ extension SessionStartView {
             setTitleLabelNoCrew()
             return
         }
+        guard isValidDay(crewData: crewData) else {
+            titleLabel.text = ""
+            return
+        }
         if firebaseManager.isDriver(crewData: crewData) {
             setTitleForDriver(crewData: crewData)
         } else {
             setTitleForMember(crewData: crewData)
         }
+    }
+
+    private func isValidDay(crewData: Crew) -> Bool {
+        guard let repeatDay = crewData.repeatDay, let today = DayOfWeek.stringToInt(Date().toDay) else {
+            return false
+        }
+        return repeatDay.contains(today)
     }
 
     private func setTitleLabelNoCrew() {
@@ -246,6 +257,10 @@ extension SessionStartView {
     func setUnderLabel(crewData: Crew?) {
         guard let crewData = crewData else {
             setUnderLabelNoCrew()
+            return
+        }
+        guard isValidDay(crewData: crewData) else {
+            underLabel.text = "오늘은 운행하지 않는 날이에요"
             return
         }
         if firebaseManager.isDriver(crewData: crewData) {
@@ -390,6 +405,10 @@ extension SessionStartView {
     }
 
     private func setBottomButtonForDriver(crewData: Crew) {
+        guard isValidDay(crewData: crewData) else {
+            setBottomButtonDriverDecline(crewData: crewData)
+            return
+        }
         switch crewData.sessionStatus {
         case .waiting:
             setBottomButtonDriverWaiting(crewData: crewData)
@@ -404,6 +423,12 @@ extension SessionStartView {
     }
 
     private func setBottomButtonForMember(crewData: Crew) {
+        guard isValidDay(crewData: crewData) else {
+            individualButton.showButton(title: "따로가요", enabled: false)
+            togetherButton.showButton(title: "함께가요", enabled: false)
+            shuttleStartButton.hideButton()
+            return
+        }
         if crewData.sessionStatus == .decline {
             setBottomButtonMemberDecline(crewData: crewData)
             return


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Feat: 새로운 기능을 추가

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

크루 생성시 설정한 요일이 아닐 때 운행하지 못하도록 하는 기능을 개발했습니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #361 

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #361 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

운전자, 탑승자 화면은 같고 버튼명만 달라집니다

<img width="300" alt="" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/22979718/281b246c-0be0-44d2-aced-1a96d45820f0">