### PR TITLE
[Fix] 로그인, 회원탈퇴 시 제대로 처리되지 않는 문제 해결

### DIFF
--- a/Carmu/Sources/SceneDelegate.swift
+++ b/Carmu/Sources/SceneDelegate.swift
@@ -58,7 +58,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /**
      window navigationController rootViewController 변경 메서드
      */
-    private func updateRootViewController() {
+    func updateRootViewController() {
         var navigationController = UINavigationController(rootViewController: UIViewController())
         navigationController.navigationBar.tintColor = UIColor.semantic.accPrimary
 

--- a/Carmu/Sources/SceneDelegate.swift
+++ b/Carmu/Sources/SceneDelegate.swift
@@ -32,9 +32,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         let window = UIWindow(windowScene: windowScene)
-        self.window = window
         // 라이트모드 고정
         window.overrideUserInterfaceStyle = .light
+        self.window = window
 
         // 스플래시 뷰
         let navigationController = UINavigationController(rootViewController: LaunchScreenViewController())

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -64,13 +64,9 @@ class FirebaseManager {
         guard let email = firebaseUser.email else {
             return
         }
-        // 디바이스 토큰값 갱신
-        guard let fcmToken = KeychainItem.currentUserDeviceToken else {
-            return
-        }
         var newUserValue = updatedUser
         newUserValue.email = email
-        newUserValue.deviceToken = fcmToken
+        newUserValue.deviceToken = KeychainItem.currentUserDeviceToken ?? ""
         let user = newUserValue
 
         do {
@@ -139,6 +135,24 @@ class FirebaseManager {
         }
         let profileImageColorValue = imageColor.rawValue
         databasePath.child("profileImageColor").setValue(profileImageColorValue as NSString)
+    }
+
+    /**
+     DB에서 유저 데이터 삭제
+     - 호출되는 곳
+        - SettingsViewController
+     */
+    func deleteUser() async throws {
+        print("유저 데이터 삭제 중...")
+        guard let databasePath = User.databasePathWithUID else {
+            return
+        }
+        do {
+            try await databasePath.setValue(nil)
+            print("유저 데이터가 삭제되었습니다!!")
+        } catch {
+            print("유저 데이터 삭제 중 오류 발생")
+        }
     }
 }
 

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -30,13 +30,9 @@ class FirebaseManager {
             return
         }
 
-        guard let fcmToken = KeychainItem.currentUserDeviceToken else {
-            return
-        }
-        print("FCMToken -> ", fcmToken)
         let user = User(
             id: firebaseUser.uid,
-            deviceToken: fcmToken,
+            deviceToken: KeychainItem.currentUserDeviceToken ?? "",
             nickname: nickname,
             email: email,
             profileImageColor: .blue // 기본 프로필


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] Fix: 버그 수정
- [X] Refactor: 프로덕션 코드 리팩토링

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

### ✅ 로그인, 로그아웃 시 처리돼야 하는 태스크가 일부만 처리되는 문제를 해결했습니다.
- 로그아웃, 회원탈퇴 시 디바이스 토큰값(`fcmToken`)을 삭제하는 로직이 있는데, 이 때 디바이스 토큰값이 삭제되면서 앱을 끄거나 다시 빌드하지 않고 바로 회원가입을 하면 `createUser()` 메서드에서 `fcmToken`값이 없어서 DB에 유저 데이터가 추가되지 않고 리턴되는 문제가 있었습니다.
  - 로그아웃, 회원탈퇴 시 키체인의 디바이스 토큰값을 삭제하지 않도록 수정했고, createUser와 updateUser 메서드에서도 디바이스 토큰값이 없으면 빈 문자열을 넣어주도록 수정했습니다.
  <img width="461" alt="스크린샷 2023-11-27 오후 5 26 37" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/3a89f347-3484-4147-b265-56859328e6e1">

### ✅ 로그인 이후 화면 전환 방식을 수정했습니다.
- isFirst값을 체크해서 최초 로그인이면 온보딩 화면으로, 재로그인이면 sessionStartView로 넘어가도록 수정했습니다.
  <img width="631" alt="스크린샷 2023-11-27 오후 5 29 30" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/08acd8df-0fe4-4c63-8a17-8366140bd9c7">


<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #323


<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #323

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

### 💡회원가입 → 회원탈퇴 → 다시 회원가입 → 로그아웃 순서대로 동작하는 영상입니다.
- DB랑 인증정보 갱신되는 것 확인 했고, 회원가입/재로그인 별로 다르게 화면 집입하는 부분 확인해주시면 될 것 같습니다.

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/7e9a97cc-838e-431d-80ab-2522bc5175a0

### ‼️ fcmToken값을 uid 불러오는 것처럼 앱 상에서 필요할 때마다 불러올 수 있는 것 같습니다.
- 탐라한테 받은 해당 코드 활용해서 나중에 디바이스토큰값 갱신하는 로직을 수정하면 좋을 것 같습니다.
```
  func getFCM() {
    Messaging.messaging().token { token, error in
      if let error = error {
        print("Error fetching FCM registration token: \(error)")
      } else if let token = token {
        print("FCM registration token: \(token)")
        self.fcmToken = token
      }
    }
  }
```
### ‼️ 로그인, 회원탈퇴 등의 경우 처리되는 태스크가 많다 보니까 대기해야 하는 시간이 있습니다. 이 때 다른 동작을 하지 않도록 로딩 화면 등을 추가해야 할 것 같습니다.

### ‼️ 로그인 시 화면이 전환되면 SceneDelegate에서 생성한 내비게이션 컨트롤러에 push되도록 수정했습니다.
- 이러면서 로그인 화면 전환 시 애니메이션 효과가 사라졌는데 나중에 추가하면 좋을 것 같습니다. (`animated=true`로 설정해줘도 그냥 화면이 띡 바뀌어 버리네요...)
