### PR TITLE
[HOTFIX] ‼️초대코드 입력 시 크루 데이터 잘못 들어가는 문제

### DIFF
--- a/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Crew/BoardingPointSelectViewController.swift
@@ -28,7 +28,6 @@ final class BoardingPointSelectViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.layer.insertSublayer(CrewMakeUtil.backGroundLayer(view), at: 0)
-
         boardingPointSelectView.customTableVieWCell = {
             var buttons: [StopoverSelectButton] = []
             var timeAddressTuple: [(String?, Date)] = []

--- a/Carmu/Sources/Utils/FirebaseManager.swift
+++ b/Carmu/Sources/Utils/FirebaseManager.swift
@@ -375,29 +375,25 @@ extension FirebaseManager {
         guard let crewID = try await readUserCrewID() else { return }
         guard var crewData = try await getCrewData(crewID: crewID) else { return }
 
-        var newPoints = [Point?]()
         // 해당 동승자의 memberStatus 삭제
         let newMemberStatus = crewData.memberStatus?.filter { memberStatus in
             memberStatus.id != KeychainItem.currentUserIdentifier
         }
         // 해당 동승자가 있는 point에서 동승자 정보 삭제
-        var pointArray = [
+        var newPoints = [Point?]()
+        var points = [
             crewData.startingPoint,
             crewData.stopover1,
             crewData.stopover2,
             crewData.stopover3
         ]
-        for idx in 0..<pointArray.count {
-            if var crews = pointArray[idx]?.crews {
-                for crewIdx in 0..<crews.count {
-                    if crews[crewIdx] == KeychainItem.currentUserIdentifier {
-                        crews.remove(at: crewIdx)
-                        pointArray[idx]?.crews = crews
-                    }
-                }
+        for idx in 0..<points.count {
+            if var crews = points[idx]?.crews {
+                crews = crews.filter { $0 != KeychainItem.currentUserIdentifier }
+                points[idx]?.crews = crews
             }
         }
-        newPoints = pointArray
+        newPoints = points
 
         crewData.memberStatus = newMemberStatus
         crewData.startingPoint = newPoints[0]


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?
- [x] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

✅ 크루 데이터가 잘못 들어가는 문제를 해결하였습니다.
    - 앱을 껐다 켰을 때에는 정상적으로 동작하나, 앱을 끄지 않은 상태로 크루에서 나간 뒤, 다시 초대 코드를 입력하여 들어가면 크루 데이터가 Point에 들어가는 오류가 있었습니다.
    - 해당 부분은 getData()에 대한 버그로써, observeSingleEvent()를 통해 해결해주었습니다.
✅ 인덱스 번호에 따른 Firebase 데이터 처리를 진행해주었습니다.
    - 만약 2개 이상의 데이터가 있을 때 첫 번째 데이터를 삭제한다면 Out of bound 에러가 나타나는 경우가 있었습니다.
    - filter 함수를 통해 해당 에러를 수정하였습니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: N/A

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #354 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.

다음은 getData 관련 레퍼런스 입니다.

https://stackoverflow.com/questions/71230278/firebase-database-getdata-returns-wrong-snapshot-if-parent-value-change-was

<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
