### PR TITLE
[Fix] 크루 편집 시 사용성 및 디자인 개선

### DIFF
--- a/Carmu/Sources/Controllers/MyPage/CrewEdit/CrewEditViewController.swift
+++ b/Carmu/Sources/Controllers/MyPage/CrewEdit/CrewEditViewController.swift
@@ -289,7 +289,6 @@ extension CrewEditViewController: PointEditTableViewCellDelegate {
         let timeSelectModalVC = TimeSelectModalViewController()
         // 시간 설정 모달에 넘겨줄 기존 시간값
         let originalTimeValue = Date.formattedDate(string: sender.titleLabel?.text ?? "오전 08:00", dateFormat: "aa hh:mm") ?? Date()
-        // TODO: - Crew에 정보 입력하는 방식 이후, 타임 피커에 이전 경유지보다 늦은 시간부터 설정하는 로직 구현예정
         // 시간 설정 모달에 기존의 값을 반영
         timeSelectModalVC.timeSelectModalView.timePicker.date = originalTimeValue
 
@@ -332,7 +331,7 @@ extension CrewEditViewController: PointEditTableViewCellDelegate {
             print("👉stopover2: \(String(describing: self.newUserCrewData.stopover2))")
             print("👉stopover3: \(String(describing: self.newUserCrewData.stopover3))")
             print("👉destination: \(String(describing: self.newUserCrewData.destination))")
-            sender.setTitle(newPointData.pointName, for: .normal)
+            sender.configuration?.attributedTitle = self.subhead2AttributedString(title: newPointData.pointName)
             switch sender.pointType {
             case .start:
                 self.newUserCrewData.startingPoint?.name = newPointData.pointName

--- a/Carmu/Sources/Controllers/MyPage/CrewEdit/CrewEditViewController.swift
+++ b/Carmu/Sources/Controllers/MyPage/CrewEdit/CrewEditViewController.swift
@@ -437,13 +437,14 @@ extension CrewEditViewController: PointEditTableViewCellDelegate {
             print("👉 stopoverPoint\(idx+1): \(String(describing: point))")
         }
         print("경유지 추가 버튼 클릭")
+        let centerLatLng = calculateCenterLatLng(crewData: newUserCrewData)
         switch sender.pointType {
         case .stopover1:
-            stopoverPoints[0] = Point(name: "주소를 검색해주세요", detailAddress: "상세주소", latitude: 35.634, longitude: 128.523, arrivalTime: Date())
+            stopoverPoints[0] = Point(name: "주소를 검색해주세요", detailAddress: "상세주소", latitude: centerLatLng.0, longitude: centerLatLng.1, arrivalTime: Date())
         case .stopover2:
-            stopoverPoints[1] = Point(name: "주소를 검색해주세요", detailAddress: "상세주소", latitude: 35.634, longitude: 128.523, arrivalTime: Date())
+            stopoverPoints[1] = Point(name: "주소를 검색해주세요", detailAddress: "상세주소", latitude: centerLatLng.0, longitude: centerLatLng.1, arrivalTime: Date())
         case .stopover3:
-            stopoverPoints[2] = Point(name: "주소를 검색해주세요", detailAddress: "상세주소", latitude: 35.634, longitude: 128.523, arrivalTime: Date())
+            stopoverPoints[2] = Point(name: "주소를 검색해주세요", detailAddress: "상세주소", latitude: centerLatLng.0, longitude: centerLatLng.1, arrivalTime: Date())
         default:
             break
         }
@@ -460,6 +461,26 @@ extension CrewEditViewController: PointEditTableViewCellDelegate {
         newUserCrewData.stopover1 = stopoverPoints[0]
         newUserCrewData.stopover2 = stopoverPoints[1]
         newUserCrewData.stopover3 = stopoverPoints[2]
+    }
+
+    // 현재 크루에 포함되어있는 경유지들에 대해서 중간 좌표값을 계산해주는 메서드
+    private func calculateCenterLatLng(crewData: Crew) -> (Double, Double) {
+        let points = [
+            crewData.startingPoint,
+            crewData.stopover1,
+            crewData.stopover2,
+            crewData.stopover3,
+            crewData.destination
+        ]
+        let nonNilPoints = points.compactMap { $0 }
+        var centerLat: Double = 0
+        var centerLng: Double = 0
+        for point in nonNilPoints {
+            centerLat += point.latitude ?? 0
+            centerLng += point.longitude ?? 0
+        }
+        let nonNilCnt = Double(nonNilPoints.count)
+        return (centerLat/nonNilCnt, centerLng/nonNilCnt)
     }
 }
 

--- a/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointView.swift
+++ b/Carmu/Sources/Views/CrewMake/Driver/StopoverPointSelect/SelectDetailStopoverPointView.swift
@@ -196,26 +196,27 @@ extension SelectDetailStopoverPointView {
         }
     }
 
-    func showPoints(points: PointLatLng) {
+    func showPoints(points: PointLatLng, isValueSetted: [Bool]) {
         startingPoint.position = NMGLatLng(lat: points.startingPoint.lat, lng: points.startingPoint.lng)
         startingPoint.anchor = CGPoint(x: 0.5, y: 0.5)
         startingPoint.mapView = mapView
-
-        if let coordinate = points.pickupLocation1 {
+        
+        // 추가만 하고 아직 주소값이 설정되지 않은 경유지는 마커 표시하지 않음
+        if let coordinate = points.pickupLocation1, isValueSetted[0] == true {
             pickupLocation1.hidden = false
             pickupLocation1.position = coordinate
             pickupLocation1.anchor = CGPoint(x: 0.5, y: 0.5)
             pickupLocation1.mapView = mapView
         }
 
-        if let coordinate = points.pickupLocation2 {
+        if let coordinate = points.pickupLocation2, isValueSetted[1] == true {
             pickupLocation2.hidden = false
             pickupLocation2.position = coordinate
             pickupLocation2.anchor = CGPoint(x: 0.5, y: 0.5)
             pickupLocation2.mapView = mapView
         }
 
-        if let coordinate = points.pickupLocation3 {
+        if let coordinate = points.pickupLocation3, isValueSetted[2] == true {
             pickupLocation3.hidden = false
             pickupLocation3.position = coordinate
             pickupLocation3.anchor = CGPoint(x: 0.5, y: 0.5)


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] Feat: 새로운 기능을 추가
- [X] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

### ✅ 추가하는 경유지의 초기값이 기존 경유지들의 중간값으로 설정되도록 했습니다.
- 경유지를 추가만 하고 주소가 설정되지 않았을 때 기존 출발지-경유지-도착지 좌표의 중간값으로 지도의 초기 화면이 세팅됩니다.
  - SelectDetailStopoverPointViewController에서 stopover1,2,3에 대해 주소값이 세팅되어 있는지를 판별하는 배열을 추가했습니다.
    <img width="852" alt="스크린샷 2023-11-27 오후 11 28 39" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/168ff7ff-0a2b-4622-9e8c-97222b746274">
  - 해당 배열을 통해서 주소값이 들어 있는 경유지인지를 확인한 뒤 지도에 표시될지 말지를 정하도록 수정했습니다.
  - ex) SelectDetailStopoverPointView에서의 마커 표시 여부 결정
    <img width="693" alt="스크린샷 2023-11-27 오후 11 32 12" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/a386058d-64b7-4861-ab4b-b65892ec57d6">

### ✅ 주소 추가 시 폰트가 적용되지 않는 문제를 수정했습니다.
- 주소 추가 시 주소 정보를 `attributedTitle`가 아니라 `setTitle()`로 설정해주고 있어서 폰트가 적용되지 않고 있었습니다. 해당 부분을 `attributedTitle` 값으로 설정하도록 수정했습니다.
<img width="731" alt="스크린샷 2023-11-27 오후 11 26 32" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/acdd345c-dbc2-47fb-8173-144d2db7b060">


<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #353

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #353

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/63e1bf75-41b2-4ee7-9b05-5b70bb0c1a37

