### PR TITLE
[Feat] 로그인/로그아웃/회원탈퇴 시 로딩 화면 표시

### DIFF
--- a/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
+++ b/Carmu/Sources/Controllers/CrewMake/Driver/StopoverPointCheckViewController.swift
@@ -40,7 +40,6 @@ final class StopoverPointCheckViewController: UIViewController {
 extension StopoverPointCheckViewController {
 
     @objc private func yesButtonTapped() {
-        // TODO: - 경유지 설정 화면으로 이동 구현 필요
         let viewController = StopoverPointSelectViewController(crewData: crewData)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/Carmu/Sources/Controllers/LoginViewController.swift
+++ b/Carmu/Sources/Controllers/LoginViewController.swift
@@ -34,12 +34,26 @@ final class LoginViewController: UIViewController {
             make.edges.equalToSuperview()
         }
     }
+
+    private func showLoginLoading() {
+        print("로그인 대기 중...")
+        loginView.isUserInteractionEnabled = false // 터치 이벤트 제한
+        loginView.activityIndicator.startAnimating()
+        loginView.activityIndicatorLabel.isHidden = false
+    }
+    private func hideLoginLoading() {
+        print("로그인 대기 종료")
+        loginView.isUserInteractionEnabled = true // 터치 이벤트 제한 해제
+        loginView.activityIndicator.stopAnimating()
+        loginView.activityIndicatorLabel.isHidden = true
+    }
 }
 // MARK: - Authorization 처리 관련 델리게이트 프로토콜 구현
 extension LoginViewController: ASAuthorizationControllerDelegate {
 
     // MARK: - 인증 성공 시 authorization을 리턴하는 메소드
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        showLoginLoading()
         guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
             fatalError("Credential을 찾을 수 없습니다.")
         }
@@ -85,6 +99,10 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
             } else {
                 let sessionStartVC = SessionStartViewController()
                 self.navigationController?.pushViewController(sessionStartVC, animated: true)
+            }
+            // SceneDelegate의 updateRootViewController가 실행되며 대기하는 3초동안 기다린 후 activity indicator 숨김
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                self.hideLoginLoading()
             }
         }
     }

--- a/Carmu/Sources/Views/LoginView.swift
+++ b/Carmu/Sources/Views/LoginView.swift
@@ -10,6 +10,25 @@ import UIKit
 
 final class LoginView: UIView {
 
+    // 로그인 처리 시 액티비티 인디케이터 뷰
+    lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.style = UIActivityIndicatorView.Style.large
+        activityIndicator.color = UIColor.semantic.backgroundThird
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.isHidden = true
+        return activityIndicator
+    }()
+    lazy var activityIndicatorLabel: UILabel = {
+        let activityIndicatorLabel = UILabel()
+        activityIndicatorLabel.text = "로그인 중..."
+        activityIndicatorLabel.textAlignment = .center
+        activityIndicatorLabel.font = UIFont.carmuFont.subhead3
+        activityIndicatorLabel.textColor = UIColor.semantic.textBody
+        activityIndicatorLabel.isHidden = true
+        return activityIndicatorLabel
+    }()
+
     // MARK: - 앱 로고
     lazy var appLogoView = GifView(gifName: "launchGif")
 
@@ -59,6 +78,8 @@ final class LoginView: UIView {
         addSubview(sloganLabel)
         addSubview(appleSignInButton)
         addSubview(corpName)
+        addSubview(activityIndicator)
+        addSubview(activityIndicatorLabel)
     }
 
     func setAutoLayout() {
@@ -84,6 +105,15 @@ final class LoginView: UIView {
         corpName.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.bottom.equalTo(safeAreaLayoutGuide).inset(16)
+        }
+
+        activityIndicator.snp.makeConstraints { make in
+            make.top.equalTo(appLogoView.snp.bottom).offset(20)
+            make.centerX.equalToSuperview()
+        }
+        activityIndicatorLabel.snp.makeConstraints { make in
+            make.top.equalTo(activityIndicator.snp.bottom).offset(20)
+            make.centerX.equalToSuperview()
         }
     }
 }

--- a/Carmu/Sources/Views/MyPage/CrewInfo/CrewInfoDriverView.swift
+++ b/Carmu/Sources/Views/MyPage/CrewInfo/CrewInfoDriverView.swift
@@ -49,7 +49,7 @@ final class CrewInfoDriverView: UIView {
         addSubview(crewManageTableView)
         crewManageTableView.snp.makeConstraints { make in
             make.top.equalTo(crewManageTitleLabel.snp.bottom).offset(16)
-            make.leading.trailing.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
         }
     }

--- a/Carmu/Sources/Views/MyPage/Settings/SettingsView.swift
+++ b/Carmu/Sources/Views/MyPage/Settings/SettingsView.swift
@@ -9,6 +9,25 @@ import UIKit
 
 final class SettingsView: UIView {
 
+    // 로그아웃/회원탈퇴 처리 시 액티비티 인디케이터 뷰
+    lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.style = UIActivityIndicatorView.Style.large
+        activityIndicator.color = UIColor.semantic.accPrimary
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.isHidden = true
+        return activityIndicator
+    }()
+    lazy var activityIndicatorLabel: UILabel = {
+        let activityIndicatorLabel = UILabel()
+        activityIndicatorLabel.text = "로그아웃 중..."
+        activityIndicatorLabel.textAlignment = .center
+        activityIndicatorLabel.font = UIFont.carmuFont.subhead3
+        activityIndicatorLabel.textColor = UIColor.semantic.textBody
+        activityIndicatorLabel.isHidden = true
+        return activityIndicatorLabel
+    }()
+
     // MARK: - 설정 화면 테이블 뷰
     lazy var settingsTableView: UITableView = {
         let settingsTableView = UITableView(frame: self.bounds, style: .insetGrouped)
@@ -71,6 +90,16 @@ final class SettingsView: UIView {
             make.centerX.equalToSuperview()
             make.bottom.equalTo(appVersionLabel.snp.top).offset(-12)
             make.height.equalTo(18)
+        }
+
+        addSubview(activityIndicator)
+        addSubview(activityIndicatorLabel)
+        activityIndicator.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        activityIndicatorLabel.snp.makeConstraints { make in
+            make.top.equalTo(activityIndicator.snp.bottom).offset(20)
+            make.centerX.equalToSuperview()
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [X] Feat: 새로운 기능을 추가

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

### ✅ 로그인, 로그아웃, 회원탈퇴 처리 중 로딩 화면이 표시되도록 했습니다.
- 그냥 기본 `UIActivityIndicatorView`를 사용했습니다. 디자인 같은건 나중에 더 구체적으로 정할 필요가 있어 보입니다.
  <img width="454" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/6f992ac5-ae70-456e-b4c5-cfa25e7884c5">

- 처리 중에는 해당 뷰의 터치 이벤트를 비활성화 시켜서 다른 이벤트가 개입하지 않도록 했습니다.
  <img width="481" alt="스크린샷 2023-11-28 오전 2 31 33" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/f8e3764f-d34d-4ac4-9974-31a82e42cfa3">

- ‼️ 처리가 다 끝나면 그 때 맞춰서 로딩 뷰를 없애고 싶은데 비동기 처리라 당장은 맞추기가 어렵네요ㅠ 일단 DispatchQueue로 2-3초 정도 대기하는 텀을 줬습니다.
  <img width="717" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/0be69704-bad8-4024-b111-2ea0b9c5bfa2">


<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #368

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #368

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/89764127/10b12649-9545-4c40-a467-83e62da3aaf0

