### PR TITLE
[Fix] 운전자가 '지각 알리기' 누를시 탑승자 화면에 시간이 제대로 표시되지 않는 현상 수정

### DIFF
--- a/Carmu/Sources/Extensions/Date+Extension.swift
+++ b/Carmu/Sources/Extensions/Date+Extension.swift
@@ -52,4 +52,8 @@ extension Date {
         dateFormatter.timeZone = .autoupdatingCurrent
         return dateFormatter.string(from: self)
     }
+
+    func withAddedMinutes(minutes: UInt) -> Date {
+        addingTimeInterval(Double(minutes) * 60)
+    }
 }

--- a/Carmu/Sources/Views/Map/MapDetailView.swift
+++ b/Carmu/Sources/Views/Map/MapDetailView.swift
@@ -237,10 +237,10 @@ final class MapDetailView: UIView {
     }
 
     private func changeTimeLabel() {
-        guard let crew = crew, let myPickUpLocation = FirebaseManager().myPickUpLocation(crew: crew) else { return }
-        guard let splitted = myPickUpLocation.arrivalTime?.toString24HourClock.split(separator: ":") else { return }
-        let minutes = (UInt(splitted[0]) ?? 0) * 60 + (UInt(splitted[1]) ?? 0) + crew.lateTime
-        pickUpTimeLabel.text = "\(minutes / 60):\(minutes % 60)"
+        guard let crew = crew,
+              let myPickUpLocation = FirebaseManager().myPickUpLocation(crew: crew),
+              let time = myPickUpLocation.arrivalTime else { return }
+        pickUpTimeLabel.text = time.withAddedMinutes(minutes: crew.lateTime).toString24HourClock
         pickUpTimeLabel.textColor = crew.lateTime > 0 ? UIColor.semantic.negative : UIColor.semantic.accPrimary
         lateTimeLabel.text = "(+\(crew.lateTime)분)"
     }


### PR DESCRIPTION
## PR Checklist

아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 아래 체크리스트를 확인하여 PR이 아래 항목들을 충족하는지 확인합니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [x] 추가/변경사항에 대한 테스트는 진행했나요?

## PR Type

어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. **(편집기 상에서는 [X] 표시하면 체크됩니다.)**
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크해줍니다. (편집기 상에서는 [X] 표시하면 체크됩니다.) -->

- [x] Fix: 버그 수정

## What is the current behavior?
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
추가/변경사항에 대해 작성해주세요.

예를 들어, 원래 탑승시간이 12:57일 때 운전자가 5분 지각을 누를 경우 13:02으로 표시되어야 하나
13:2로 표시되고 있어 수정이 필요합니다.

<!-- 관련 이슈 번호도 함께 표기해주세요 ex) Issue Number: #43 -->
Issue Number: #383 

<!-- 해당 이슈가 해결되었다면 이슈번호를 작성해주세요. ex) Resolved: #43 -->
Resolved: #383 

## Other information
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
<!--
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

<img width="300" alt="" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-DGC/assets/22979718/0886bdb1-07fe-4a00-a6a1-924657ca9898">
